### PR TITLE
Adjust shockwave and confetti effect

### DIFF
--- a/StarterPlayer/StarterPlayerScripts/WheelConfettiClient.lua
+++ b/StarterPlayer/StarterPlayerScripts/WheelConfettiClient.lua
@@ -159,9 +159,9 @@ SpinResult.OnClientEvent:Connect(function(ok, phase, label, amount, boostSeconds
 			
 			if wheelModel then
 				if wheelModel:IsA("Model") and wheelModel.PrimaryPart then
-					position = wheelModel.PrimaryPart.Position + Vector3.new(0, 5, 0)
+					position = wheelModel.PrimaryPart.Position + Vector3.new(0, 2, 0)
 				elseif wheelModel:IsA("BasePart") then
-					position = wheelModel.Position + Vector3.new(0, 5, 0)
+					position = wheelModel.Position + Vector3.new(0, 2, 0)
 				end
 			end
 			
@@ -185,7 +185,7 @@ SpinResult.OnClientEvent:Connect(function(ok, phase, label, amount, boostSeconds
 				shockwave.Size = Vector3.new(0.1, 0.1, 0.1)
 				shockwave.Material = Enum.Material.ForceField
 				shockwave.Color = Color3.fromRGB(255, 215, 0)
-				shockwave.Transparency = 0.5
+				shockwave.Transparency = 0.3
 				shockwave.CanCollide = false
 				shockwave.Anchored = true
 				shockwave.Position = position
@@ -193,9 +193,9 @@ SpinResult.OnClientEvent:Connect(function(ok, phase, label, amount, boostSeconds
 				shockwave.Parent = workspace
 				
 				TweenService:Create(shockwave,
-					TweenInfo.new(1, Enum.EasingStyle.Quad, Enum.EasingDirection.Out),
+					TweenInfo.new(0.8, Enum.EasingStyle.Quad, Enum.EasingDirection.Out),
 					{
-						Size = Vector3.new(30, 30, 30),
+						Size = Vector3.new(15, 15, 15),
 						Transparency = 1
 					}
 				):Play()


### PR DESCRIPTION
Reduce shockwave effect to be less explosive and lower confetti height on the wheel.

---
<a href="https://cursor.com/background-agent?bcId=bc-47adcc99-5b67-497a-976d-7d7efefcaab5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-47adcc99-5b67-497a-976d-7d7efefcaab5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

