### PR TITLE
Adjust shockwave and confetti effect

### DIFF
--- a/StarterPlayer/StarterPlayerScripts/WheelConfettiClient.lua
+++ b/StarterPlayer/StarterPlayerScripts/WheelConfettiClient.lua
@@ -52,7 +52,7 @@ local function createConfettiParticle(position: Vector3)
 	bodyVelocity.MaxForce = Vector3.new(math.huge, math.huge, math.huge)
 	bodyVelocity.Velocity = Vector3.new(
 		math.random(-20, 20),
-		math.random(15, 30),
+		math.random(10, 20),
 		math.random(-20, 20)
 	)
 	bodyVelocity.Parent = particle
@@ -159,9 +159,9 @@ SpinResult.OnClientEvent:Connect(function(ok, phase, label, amount, boostSeconds
 			
 			if wheelModel then
 				if wheelModel:IsA("Model") and wheelModel.PrimaryPart then
-					position = wheelModel.PrimaryPart.Position + Vector3.new(0, 5, 0)
+				position = wheelModel.PrimaryPart.Position + Vector3.new(0, 3, 0)
 				elseif wheelModel:IsA("BasePart") then
-					position = wheelModel.Position + Vector3.new(0, 5, 0)
+				position = wheelModel.Position + Vector3.new(0, 3, 0)
 				end
 			end
 			
@@ -177,7 +177,7 @@ SpinResult.OnClientEvent:Connect(function(ok, phase, label, amount, boostSeconds
 			-- If it's a big win (50K or 2X boost), make it extra special
 			if (amount and amount >= 50000) or (boostSeconds and boostSeconds > 0) then
 				task.wait(0.2)
-				createConfettiBurst(position + Vector3.new(0, 2, 0), 80)
+				createConfettiBurst(position + Vector3.new(0, 1, 0), 80)
 				
 				-- Create a shockwave effect
 				local shockwave = Instance.new("Part")
@@ -185,7 +185,7 @@ SpinResult.OnClientEvent:Connect(function(ok, phase, label, amount, boostSeconds
 				shockwave.Size = Vector3.new(0.1, 0.1, 0.1)
 				shockwave.Material = Enum.Material.ForceField
 				shockwave.Color = Color3.fromRGB(255, 215, 0)
-				shockwave.Transparency = 0.5
+				shockwave.Transparency = 0.7
 				shockwave.CanCollide = false
 				shockwave.Anchored = true
 				shockwave.Position = position
@@ -193,14 +193,14 @@ SpinResult.OnClientEvent:Connect(function(ok, phase, label, amount, boostSeconds
 				shockwave.Parent = workspace
 				
 				TweenService:Create(shockwave,
-					TweenInfo.new(1, Enum.EasingStyle.Quad, Enum.EasingDirection.Out),
+					TweenInfo.new(0.8, Enum.EasingStyle.Quad, Enum.EasingDirection.Out),
 					{
-						Size = Vector3.new(30, 30, 30),
+						Size = Vector3.new(18, 18, 18),
 						Transparency = 1
 					}
 				):Play()
 				
-				Debris:AddItem(shockwave, 1.1)
+				Debris:AddItem(shockwave, 0.9)
 			end
 		end
 	end


### PR DESCRIPTION
Reduce shockwave intensity and lower confetti spawn height to make effects less pronounced.

---
<a href="https://cursor.com/background-agent?bcId=bc-8569744e-e67e-43ea-aeeb-a0148664bcd3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-8569744e-e67e-43ea-aeeb-a0148664bcd3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

