### PR TITLE
Adjust dropper values and collision behavior

### DIFF
--- a/Dropper10_NEW.lua
+++ b/Dropper10_NEW.lua
@@ -1,0 +1,64 @@
+--[[
+	Dropper 10 NEW - Golden Glass
+	Optimized with anti-stack
+--]]
+
+local AntiStack = require(workspace:WaitForChild("DropperAntiStack"))
+
+-- Setup collision groups
+AntiStack.SetupCollisionGroups()
+
+-- Setup player collisions
+game.Players.PlayerAdded:Connect(function(player)
+	player.CharacterAdded:Connect(AntiStack.SetupPlayerCollisions)
+end)
+
+for _, player in ipairs(game.Players:GetPlayers()) do
+	if player.Character then
+		AntiStack.SetupPlayerCollisions(player.Character)
+	end
+end
+
+-- Wait for dependencies
+task.wait(2)
+local PartStorage = workspace:WaitForChild("PartStorage")
+local dropPart = script.Parent:WaitForChild("Drop")
+
+local dropCount = 0
+
+while true do
+	task.wait(0.45)
+	
+	-- Debounce check to prevent spam
+	if not AntiStack.CanDrop(0.4) then
+		continue
+	end
+	
+	dropCount = dropCount + 1
+
+	-- Create part
+	local part = Instance.new("Part")
+	part.Name = "GoldenDrop10_" .. dropCount
+	part.BrickColor = BrickColor.new("New Yeller")
+	part.Material = "Glass"
+	part.FormFactor = "Custom"
+	part.Size = Vector3.new(1.5, 1.5, 1.5)
+	part.TopSurface = "Smooth"
+	part.BottomSurface = "Smooth"
+	part.Reflectance = 0.4
+
+	-- Cash value
+	local cash = Instance.new("IntValue")
+	cash.Name = "Cash"
+	cash.Value = 250
+	cash.Parent = part
+
+	-- Apply anti-stack physics
+	AntiStack.ApplyAntiStackPhysics(part, dropPart)
+
+	-- Parent to storage
+	part.Parent = PartStorage
+
+	-- Long lifetime
+	AntiStack.ScheduleCleanup(part, 2000)
+end

--- a/Dropper10_NEW.lua
+++ b/Dropper10_NEW.lua
@@ -1,64 +1,65 @@
 --[[
 	Dropper 10 NEW - Golden Glass
-	Optimized with anti-stack
+	Uses DropperCore
 --]]
 
-local AntiStack = require(workspace:WaitForChild("DropperAntiStack"))
+local Core = require(game.ReplicatedStorage.Modules.DropperCore)
 
--- Setup collision groups
-AntiStack.SetupCollisionGroups()
+task.wait(1)
 
--- Setup player collisions
-game.Players.PlayerAdded:Connect(function(player)
-	player.CharacterAdded:Connect(AntiStack.SetupPlayerCollisions)
-end)
+-- Create template model
+local templateModel = Instance.new("Model")
+templateModel.Name = "Dropper10Template"
 
-for _, player in ipairs(game.Players:GetPlayers()) do
-	if player.Character then
-		AntiStack.SetupPlayerCollisions(player.Character)
-	end
+local mainPart = Instance.new("Part")
+mainPart.Name = "PrimaryPart"
+mainPart.Size = Vector3.new(1.5, 1.5, 1.5)
+mainPart.BrickColor = BrickColor.new("New Yeller")
+mainPart.Material = Enum.Material.Glass
+mainPart.TopSurface = Enum.SurfaceType.Smooth
+mainPart.BottomSurface = Enum.SurfaceType.Smooth
+mainPart.Reflectance = 0.4
+mainPart.Transparency = 0
+mainPart.Anchored = false
+mainPart.CanCollide = true
+mainPart.Parent = templateModel
+
+-- Set primary part
+templateModel.PrimaryPart = mainPart
+
+-- Store template
+local templateStorage = game.ReplicatedStorage:FindFirstChild("DropperTemplates")
+if not templateStorage then
+	templateStorage = Instance.new("Folder")
+	templateStorage.Name = "DropperTemplates"
+	templateStorage.Parent = game.ReplicatedStorage
 end
+templateModel.Parent = templateStorage
 
--- Wait for dependencies
-task.wait(2)
-local PartStorage = workspace:WaitForChild("PartStorage")
-local dropPart = script.Parent:WaitForChild("Drop")
+-- Run dropper
+Core.RunModel({
+	model = script.Parent,
+	partStorage = workspace:WaitForChild("PartStorage"),
+	templateModel = templateModel,
 
-local dropCount = 0
+	namePrefix = "Golden10_",
+	dropGroup = "HelloKittyDrops10",
+	playerGroup = "Players",
 
-while true do
-	task.wait(0.45)
+	dropRate = 0.45,
+	cashValue = 250,
+	lifetime = 2000,
+
+	scaleFactor = 1.0,
+	density = 0.3,
+	friction = 0.4,
+	elasticity = 0.1,
 	
-	-- Debounce check to prevent spam
-	if not AntiStack.CanDrop(0.4) then
-		continue
-	end
+	extraLower = 1.5,
+	fadeTime = 0.4,
 	
-	dropCount = dropCount + 1
-
-	-- Create part
-	local part = Instance.new("Part")
-	part.Name = "GoldenDrop10_" .. dropCount
-	part.BrickColor = BrickColor.new("New Yeller")
-	part.Material = "Glass"
-	part.FormFactor = "Custom"
-	part.Size = Vector3.new(1.5, 1.5, 1.5)
-	part.TopSurface = "Smooth"
-	part.BottomSurface = "Smooth"
-	part.Reflectance = 0.4
-
-	-- Cash value
-	local cash = Instance.new("IntValue")
-	cash.Name = "Cash"
-	cash.Value = 250
-	cash.Parent = part
-
-	-- Apply anti-stack physics
-	AntiStack.ApplyAntiStackPhysics(part, dropPart)
-
-	-- Parent to storage
-	part.Parent = PartStorage
-
-	-- Long lifetime
-	AntiStack.ScheduleCleanup(part, 2000)
-end
+	cashOn = "primary",
+	
+	collectorNames = {"Collector", "CollectorZone", "Receiver", "Sell", "SellPad"},
+	collectorTags = {"Collector", "SellZone"},
+})

--- a/Dropper10_NEW.lua
+++ b/Dropper10_NEW.lua
@@ -1,65 +1,73 @@
+--!strict
 --[[
-	Dropper 10 NEW - Golden Glass
-	Uses DropperCore
+	Dropper 10 NEW - Golden Glass (FIXED)
 --]]
 
-local Core = require(game.ReplicatedStorage.Modules.DropperCore)
+local PhysicsService = game:GetService("PhysicsService")
 
-task.wait(1)
+task.wait(2)
+local PartStorage = workspace:WaitForChild("PartStorage")
+local dropPart = script.Parent:WaitForChild("Drop")
 
--- Create template model
-local templateModel = Instance.new("Model")
-templateModel.Name = "Dropper10Template"
+local ORB_GROUP = "HelloKittyDrops10"
+local PLAYER_GROUP = "Players"
 
-local mainPart = Instance.new("Part")
-mainPart.Name = "PrimaryPart"
-mainPart.Size = Vector3.new(1.5, 1.5, 1.5)
-mainPart.BrickColor = BrickColor.new("New Yeller")
-mainPart.Material = Enum.Material.Glass
-mainPart.TopSurface = Enum.SurfaceType.Smooth
-mainPart.BottomSurface = Enum.SurfaceType.Smooth
-mainPart.Reflectance = 0.4
-mainPart.Transparency = 0
-mainPart.Anchored = false
-mainPart.CanCollide = true
-mainPart.Parent = templateModel
+pcall(function()
+	PhysicsService:RegisterCollisionGroup(ORB_GROUP)
+	PhysicsService:RegisterCollisionGroup(PLAYER_GROUP)
+	PhysicsService:CollisionGroupSetCollidable(ORB_GROUP, PLAYER_GROUP, false)
+	PhysicsService:CollisionGroupSetCollidable(ORB_GROUP, ORB_GROUP, false)
+end)
 
--- Set primary part
-templateModel.PrimaryPart = mainPart
-
--- Store template
-local templateStorage = game.ReplicatedStorage:FindFirstChild("DropperTemplates")
-if not templateStorage then
-	templateStorage = Instance.new("Folder")
-	templateStorage.Name = "DropperTemplates"
-	templateStorage.Parent = game.ReplicatedStorage
+local function setupPlayer(character)
+	task.wait(0.1)
+	for _, part in ipairs(character:GetDescendants()) do
+		if part:IsA("BasePart") then
+			pcall(function() part.CollisionGroup = PLAYER_GROUP end)
+		end
+	end
 end
-templateModel.Parent = templateStorage
 
--- Run dropper
-Core.RunModel({
-	model = script.Parent,
-	partStorage = workspace:WaitForChild("PartStorage"),
-	templateModel = templateModel,
+game.Players.PlayerAdded:Connect(function(player)
+	player.CharacterAdded:Connect(setupPlayer)
+end)
 
-	namePrefix = "Golden10_",
-	dropGroup = "HelloKittyDrops10",
-	playerGroup = "Players",
+for _, player in ipairs(game.Players:GetPlayers()) do
+	if player.Character then setupPlayer(player.Character) end
+end
 
-	dropRate = 0.45,
-	cashValue = 250,
-	lifetime = 2000,
+local dropCount = 0
 
-	scaleFactor = 1.0,
-	density = 0.3,
-	friction = 0.4,
-	elasticity = 0.1,
-	
-	extraLower = 1.5,
-	fadeTime = 0.4,
-	
-	cashOn = "primary",
-	
-	collectorNames = {"Collector", "CollectorZone", "Receiver", "Sell", "SellPad"},
-	collectorTags = {"Collector", "SellZone"},
-})
+while true do
+	task.wait(0.45)
+	dropCount = dropCount + 1
+
+	local part = Instance.new("Part")
+	part.Name = "Golden10_" .. dropCount
+	part.Size = Vector3.new(1.5, 1.5, 1.5)
+	part.BrickColor = BrickColor.new("New Yeller")
+	part.Material = Enum.Material.Glass
+	part.TopSurface = Enum.SurfaceType.Smooth
+	part.BottomSurface = Enum.SurfaceType.Smooth
+	part.Reflectance = 0.4
+
+	part.CanCollide = true
+	part.CanTouch = true
+	part.CanQuery = true
+	part.CollisionGroup = ORB_GROUP
+	part.CustomPhysicalProperties = PhysicalProperties.new(0.3, 0.4, 0.1, 1, 1)
+
+	local cash = Instance.new("IntValue")
+	cash.Name = "Cash"
+	cash.Value = 250
+	cash.Parent = part
+
+	local offsetX = math.random(-2, 2) * 0.1
+	local offsetZ = math.random(-2, 2) * 0.1
+	part.CFrame = (dropPart.CFrame - Vector3.new(offsetX, 1.5, offsetZ))
+	part.AssemblyLinearVelocity = Vector3.new(offsetX * 2, -10, offsetZ * 2)
+	part:SetAttribute("SpawnTime", os.clock())
+	part.Parent = PartStorage
+
+	task.delay(2000, function() if part and part.Parent then part:Destroy() end end)
+end

--- a/Dropper11_13_Fixed.lua
+++ b/Dropper11_13_Fixed.lua
@@ -62,7 +62,7 @@ while true do
 	-- Cash value
 	local cash = Instance.new("IntValue")
 	cash.Name = "Cash"
-	cash.Value = 100
+	cash.Value = 200
 	cash.Parent = part
 
 	-- Apply anti-stack physics (with higher drop offset for small parts)

--- a/Dropper11_NEW.lua
+++ b/Dropper11_NEW.lua
@@ -1,64 +1,72 @@
+--!strict
 --[[
-	Dropper 11 NEW - Ruby Red Metal
-	Uses DropperCore
+	Dropper 11 NEW - Ruby Red Metal (FIXED)
 --]]
 
-local Core = require(game.ReplicatedStorage.Modules.DropperCore)
+local PhysicsService = game:GetService("PhysicsService")
 
-task.wait(1)
+task.wait(2)
+local PartStorage = workspace:WaitForChild("PartStorage")
+local dropPart = script.Parent:WaitForChild("Drop")
 
--- Create template model
-local templateModel = Instance.new("Model")
-templateModel.Name = "Dropper11Template"
+local ORB_GROUP = "HelloKittyDrops11"
+local PLAYER_GROUP = "Players"
 
-local mainPart = Instance.new("Part")
-mainPart.Name = "PrimaryPart"
-mainPart.Size = Vector3.new(0.3, 0.3, 0.3)
-mainPart.BrickColor = BrickColor.new("Really red")
-mainPart.Material = Enum.Material.Metal
-mainPart.TopSurface = Enum.SurfaceType.Smooth
-mainPart.BottomSurface = Enum.SurfaceType.Smooth
-mainPart.Transparency = 0
-mainPart.Anchored = false
-mainPart.CanCollide = true
-mainPart.Parent = templateModel
+pcall(function()
+	PhysicsService:RegisterCollisionGroup(ORB_GROUP)
+	PhysicsService:RegisterCollisionGroup(PLAYER_GROUP)
+	PhysicsService:CollisionGroupSetCollidable(ORB_GROUP, PLAYER_GROUP, false)
+	PhysicsService:CollisionGroupSetCollidable(ORB_GROUP, ORB_GROUP, false)
+end)
 
--- Set primary part
-templateModel.PrimaryPart = mainPart
-
--- Store template
-local templateStorage = game.ReplicatedStorage:FindFirstChild("DropperTemplates")
-if not templateStorage then
-	templateStorage = Instance.new("Folder")
-	templateStorage.Name = "DropperTemplates"
-	templateStorage.Parent = game.ReplicatedStorage
+local function setupPlayer(character)
+	task.wait(0.1)
+	for _, part in ipairs(character:GetDescendants()) do
+		if part:IsA("BasePart") then
+			pcall(function() part.CollisionGroup = PLAYER_GROUP end)
+		end
+	end
 end
-templateModel.Parent = templateStorage
 
--- Run dropper
-Core.RunModel({
-	model = script.Parent,
-	partStorage = workspace:WaitForChild("PartStorage"),
-	templateModel = templateModel,
+game.Players.PlayerAdded:Connect(function(player)
+	player.CharacterAdded:Connect(setupPlayer)
+end)
 
-	namePrefix = "Ruby11_",
-	dropGroup = "HelloKittyDrops11",
-	playerGroup = "Players",
+for _, player in ipairs(game.Players:GetPlayers()) do
+	if player.Character then setupPlayer(player.Character) end
+end
 
-	dropRate = 0.4,
-	cashValue = 350,
-	lifetime = 25,
+local dropCount = 0
 
-	scaleFactor = 1.0,
-	density = 0.3,
-	friction = 0.4,
-	elasticity = 0.1,
-	
-	extraLower = 3.25,
-	fadeTime = 0.3,
-	
-	cashOn = "primary",
-	
-	collectorNames = {"Collector", "CollectorZone", "Receiver", "Sell", "SellPad"},
-	collectorTags = {"Collector", "SellZone"},
-})
+while true do
+	task.wait(0.4)
+	dropCount = dropCount + 1
+
+	local part = Instance.new("Part")
+	part.Name = "Ruby11_" .. dropCount
+	part.Size = Vector3.new(0.3, 0.3, 0.3)
+	part.BrickColor = BrickColor.new("Really red")
+	part.Material = Enum.Material.Metal
+	part.TopSurface = Enum.SurfaceType.Smooth
+	part.BottomSurface = Enum.SurfaceType.Smooth
+
+	part.CanCollide = true
+	part.CanTouch = true
+	part.CanQuery = true
+	part.CollisionGroup = ORB_GROUP
+	part.CustomPhysicalProperties = PhysicalProperties.new(0.3, 0.4, 0.1, 1, 1)
+
+	local cash = Instance.new("IntValue")
+	cash.Name = "Cash"
+	cash.Value = 350
+	cash.Parent = part
+
+	local offsetX = math.random(-2, 2) * 0.1
+	local offsetZ = math.random(-2, 2) * 0.1
+	part.CFrame = (dropPart.CFrame - Vector3.new(offsetX, 3.25, offsetZ))
+	part.AssemblyLinearVelocity = Vector3.new(offsetX * 2, -10, offsetZ * 2)
+	part:SetAttribute("SpawnTime", os.clock())
+	part.Parent = PartStorage
+
+	task.delay(25, function() if part and part.Parent then part:Destroy() end end)
+end

--- a/Dropper11_NEW.lua
+++ b/Dropper11_NEW.lua
@@ -1,0 +1,66 @@
+--[[
+	Dropper 11 NEW - Ruby Red Metallic
+	Optimized with anti-stack
+--]]
+
+local AntiStack = require(workspace:WaitForChild("DropperAntiStack"))
+
+-- Setup collision groups
+AntiStack.SetupCollisionGroups()
+
+-- Setup player collisions
+game.Players.PlayerAdded:Connect(function(player)
+	player.CharacterAdded:Connect(AntiStack.SetupPlayerCollisions)
+end)
+
+for _, player in ipairs(game.Players:GetPlayers()) do
+	if player.Character then
+		AntiStack.SetupPlayerCollisions(player.Character)
+	end
+end
+
+-- Wait for dependencies
+task.wait(2)
+local PartStorage = workspace:WaitForChild("PartStorage")
+local dropPart = script.Parent:WaitForChild("Drop")
+
+local dropCount = 0
+
+while true do
+	task.wait(0.4)
+	
+	-- Debounce check
+	if not AntiStack.CanDrop(0.35) then
+		continue
+	end
+	
+	dropCount = dropCount + 1
+
+	-- Create part
+	local part = Instance.new("Part")
+	part.Name = "RubyDrop11_" .. dropCount
+	part.BrickColor = BrickColor.new("Really red")
+	part.Material = Enum.Material.Metal
+	part.FormFactor = "Custom"
+	part.Size = Vector3.new(0.3, 0.3, 0.3)
+	part.TopSurface = "Smooth"
+	part.BottomSurface = "Smooth"
+
+	-- Cash value
+	local cash = Instance.new("IntValue")
+	cash.Name = "Cash"
+	cash.Value = 350
+	cash.Parent = part
+
+	-- Apply anti-stack physics (with higher drop offset for small parts)
+	local dropPartClone = Instance.new("Part")
+	dropPartClone.CFrame = dropPart.CFrame - Vector3.new(0, 3.25, 0)
+	AntiStack.ApplyAntiStackPhysics(part, dropPartClone)
+	dropPartClone:Destroy()
+
+	-- Parent to storage
+	part.Parent = PartStorage
+
+	-- Schedule cleanup
+	AntiStack.ScheduleCleanup(part, 25)
+end

--- a/Dropper11_NEW.lua
+++ b/Dropper11_NEW.lua
@@ -1,66 +1,64 @@
 --[[
-	Dropper 11 NEW - Ruby Red Metallic
-	Optimized with anti-stack
+	Dropper 11 NEW - Ruby Red Metal
+	Uses DropperCore
 --]]
 
-local AntiStack = require(workspace:WaitForChild("DropperAntiStack"))
+local Core = require(game.ReplicatedStorage.Modules.DropperCore)
 
--- Setup collision groups
-AntiStack.SetupCollisionGroups()
+task.wait(1)
 
--- Setup player collisions
-game.Players.PlayerAdded:Connect(function(player)
-	player.CharacterAdded:Connect(AntiStack.SetupPlayerCollisions)
-end)
+-- Create template model
+local templateModel = Instance.new("Model")
+templateModel.Name = "Dropper11Template"
 
-for _, player in ipairs(game.Players:GetPlayers()) do
-	if player.Character then
-		AntiStack.SetupPlayerCollisions(player.Character)
-	end
+local mainPart = Instance.new("Part")
+mainPart.Name = "PrimaryPart"
+mainPart.Size = Vector3.new(0.3, 0.3, 0.3)
+mainPart.BrickColor = BrickColor.new("Really red")
+mainPart.Material = Enum.Material.Metal
+mainPart.TopSurface = Enum.SurfaceType.Smooth
+mainPart.BottomSurface = Enum.SurfaceType.Smooth
+mainPart.Transparency = 0
+mainPart.Anchored = false
+mainPart.CanCollide = true
+mainPart.Parent = templateModel
+
+-- Set primary part
+templateModel.PrimaryPart = mainPart
+
+-- Store template
+local templateStorage = game.ReplicatedStorage:FindFirstChild("DropperTemplates")
+if not templateStorage then
+	templateStorage = Instance.new("Folder")
+	templateStorage.Name = "DropperTemplates"
+	templateStorage.Parent = game.ReplicatedStorage
 end
+templateModel.Parent = templateStorage
 
--- Wait for dependencies
-task.wait(2)
-local PartStorage = workspace:WaitForChild("PartStorage")
-local dropPart = script.Parent:WaitForChild("Drop")
+-- Run dropper
+Core.RunModel({
+	model = script.Parent,
+	partStorage = workspace:WaitForChild("PartStorage"),
+	templateModel = templateModel,
 
-local dropCount = 0
+	namePrefix = "Ruby11_",
+	dropGroup = "HelloKittyDrops11",
+	playerGroup = "Players",
 
-while true do
-	task.wait(0.4)
+	dropRate = 0.4,
+	cashValue = 350,
+	lifetime = 25,
+
+	scaleFactor = 1.0,
+	density = 0.3,
+	friction = 0.4,
+	elasticity = 0.1,
 	
-	-- Debounce check
-	if not AntiStack.CanDrop(0.35) then
-		continue
-	end
+	extraLower = 3.25,
+	fadeTime = 0.3,
 	
-	dropCount = dropCount + 1
-
-	-- Create part
-	local part = Instance.new("Part")
-	part.Name = "RubyDrop11_" .. dropCount
-	part.BrickColor = BrickColor.new("Really red")
-	part.Material = Enum.Material.Metal
-	part.FormFactor = "Custom"
-	part.Size = Vector3.new(0.3, 0.3, 0.3)
-	part.TopSurface = "Smooth"
-	part.BottomSurface = "Smooth"
-
-	-- Cash value
-	local cash = Instance.new("IntValue")
-	cash.Name = "Cash"
-	cash.Value = 350
-	cash.Parent = part
-
-	-- Apply anti-stack physics (with higher drop offset for small parts)
-	local dropPartClone = Instance.new("Part")
-	dropPartClone.CFrame = dropPart.CFrame - Vector3.new(0, 3.25, 0)
-	AntiStack.ApplyAntiStackPhysics(part, dropPartClone)
-	dropPartClone:Destroy()
-
-	-- Parent to storage
-	part.Parent = PartStorage
-
-	-- Schedule cleanup
-	AntiStack.ScheduleCleanup(part, 25)
-end
+	cashOn = "primary",
+	
+	collectorNames = {"Collector", "CollectorZone", "Receiver", "Sell", "SellPad"},
+	collectorTags = {"Collector", "SellZone"},
+})

--- a/Dropper12_NEW.lua
+++ b/Dropper12_NEW.lua
@@ -1,64 +1,72 @@
+--!strict
 --[[
-	Dropper 12 NEW - Diamond Blue Neon
-	Uses DropperCore
+	Dropper 12 NEW - Diamond Blue Neon (FIXED)
 --]]
 
-local Core = require(game.ReplicatedStorage.Modules.DropperCore)
+local PhysicsService = game:GetService("PhysicsService")
 
-task.wait(1)
+task.wait(2)
+local PartStorage = workspace:WaitForChild("PartStorage")
+local dropPart = script.Parent:WaitForChild("Drop")
 
--- Create template model
-local templateModel = Instance.new("Model")
-templateModel.Name = "Dropper12Template"
+local ORB_GROUP = "HelloKittyDrops12"
+local PLAYER_GROUP = "Players"
 
-local mainPart = Instance.new("Part")
-mainPart.Name = "PrimaryPart"
-mainPart.Size = Vector3.new(0.4, 0.4, 0.4)
-mainPart.BrickColor = BrickColor.new("Cyan")
-mainPart.Material = Enum.Material.Neon
-mainPart.TopSurface = Enum.SurfaceType.Smooth
-mainPart.BottomSurface = Enum.SurfaceType.Smooth
-mainPart.Transparency = 0
-mainPart.Anchored = false
-mainPart.CanCollide = true
-mainPart.Parent = templateModel
+pcall(function()
+	PhysicsService:RegisterCollisionGroup(ORB_GROUP)
+	PhysicsService:RegisterCollisionGroup(PLAYER_GROUP)
+	PhysicsService:CollisionGroupSetCollidable(ORB_GROUP, PLAYER_GROUP, false)
+	PhysicsService:CollisionGroupSetCollidable(ORB_GROUP, ORB_GROUP, false)
+end)
 
--- Set primary part
-templateModel.PrimaryPart = mainPart
-
--- Store template
-local templateStorage = game.ReplicatedStorage:FindFirstChild("DropperTemplates")
-if not templateStorage then
-	templateStorage = Instance.new("Folder")
-	templateStorage.Name = "DropperTemplates"
-	templateStorage.Parent = game.ReplicatedStorage
+local function setupPlayer(character)
+	task.wait(0.1)
+	for _, part in ipairs(character:GetDescendants()) do
+		if part:IsA("BasePart") then
+			pcall(function() part.CollisionGroup = PLAYER_GROUP end)
+		end
+	end
 end
-templateModel.Parent = templateStorage
 
--- Run dropper
-Core.RunModel({
-	model = script.Parent,
-	partStorage = workspace:WaitForChild("PartStorage"),
-	templateModel = templateModel,
+game.Players.PlayerAdded:Connect(function(player)
+	player.CharacterAdded:Connect(setupPlayer)
+end)
 
-	namePrefix = "Diamond12_",
-	dropGroup = "HelloKittyDrops12",
-	playerGroup = "Players",
+for _, player in ipairs(game.Players:GetPlayers()) do
+	if player.Character then setupPlayer(player.Character) end
+end
 
-	dropRate = 0.35,
-	cashValue = 500,
-	lifetime = 30,
+local dropCount = 0
 
-	scaleFactor = 1.0,
-	density = 0.3,
-	friction = 0.4,
-	elasticity = 0.1,
-	
-	extraLower = 3.25,
-	fadeTime = 0.3,
-	
-	cashOn = "primary",
-	
-	collectorNames = {"Collector", "CollectorZone", "Receiver", "Sell", "SellPad"},
-	collectorTags = {"Collector", "SellZone"},
-})
+while true do
+	task.wait(0.35)
+	dropCount = dropCount + 1
+
+	local part = Instance.new("Part")
+	part.Name = "Diamond12_" .. dropCount
+	part.Size = Vector3.new(0.4, 0.4, 0.4)
+	part.BrickColor = BrickColor.new("Cyan")
+	part.Material = Enum.Material.Neon
+	part.TopSurface = Enum.SurfaceType.Smooth
+	part.BottomSurface = Enum.SurfaceType.Smooth
+
+	part.CanCollide = true
+	part.CanTouch = true
+	part.CanQuery = true
+	part.CollisionGroup = ORB_GROUP
+	part.CustomPhysicalProperties = PhysicalProperties.new(0.3, 0.4, 0.1, 1, 1)
+
+	local cash = Instance.new("IntValue")
+	cash.Name = "Cash"
+	cash.Value = 500
+	cash.Parent = part
+
+	local offsetX = math.random(-2, 2) * 0.1
+	local offsetZ = math.random(-2, 2) * 0.1
+	part.CFrame = (dropPart.CFrame - Vector3.new(offsetX, 3.25, offsetZ))
+	part.AssemblyLinearVelocity = Vector3.new(offsetX * 2, -10, offsetZ * 2)
+	part:SetAttribute("SpawnTime", os.clock())
+	part.Parent = PartStorage
+
+	task.delay(30, function() if part and part.Parent then part:Destroy() end end)
+end

--- a/Dropper12_NEW.lua
+++ b/Dropper12_NEW.lua
@@ -1,0 +1,66 @@
+--[[
+	Dropper 12 NEW - Diamond Blue Neon
+	Optimized with anti-stack
+--]]
+
+local AntiStack = require(workspace:WaitForChild("DropperAntiStack"))
+
+-- Setup collision groups
+AntiStack.SetupCollisionGroups()
+
+-- Setup player collisions
+game.Players.PlayerAdded:Connect(function(player)
+	player.CharacterAdded:Connect(AntiStack.SetupPlayerCollisions)
+end)
+
+for _, player in ipairs(game.Players:GetPlayers()) do
+	if player.Character then
+		AntiStack.SetupPlayerCollisions(player.Character)
+	end
+end
+
+-- Wait for dependencies
+task.wait(2)
+local PartStorage = workspace:WaitForChild("PartStorage")
+local dropPart = script.Parent:WaitForChild("Drop")
+
+local dropCount = 0
+
+while true do
+	task.wait(0.35)
+	
+	-- Debounce check
+	if not AntiStack.CanDrop(0.3) then
+		continue
+	end
+	
+	dropCount = dropCount + 1
+
+	-- Create part
+	local part = Instance.new("Part")
+	part.Name = "DiamondDrop12_" .. dropCount
+	part.BrickColor = BrickColor.new("Cyan")
+	part.Material = Enum.Material.Neon
+	part.FormFactor = "Custom"
+	part.Size = Vector3.new(0.4, 0.4, 0.4)
+	part.TopSurface = "Smooth"
+	part.BottomSurface = "Smooth"
+
+	-- Cash value
+	local cash = Instance.new("IntValue")
+	cash.Name = "Cash"
+	cash.Value = 500
+	cash.Parent = part
+
+	-- Apply anti-stack physics (with higher drop offset for small parts)
+	local dropPartClone = Instance.new("Part")
+	dropPartClone.CFrame = dropPart.CFrame - Vector3.new(0, 3.25, 0)
+	AntiStack.ApplyAntiStackPhysics(part, dropPartClone)
+	dropPartClone:Destroy()
+
+	-- Parent to storage
+	part.Parent = PartStorage
+
+	-- Schedule cleanup
+	AntiStack.ScheduleCleanup(part, 30)
+end

--- a/Dropper12_NEW.lua
+++ b/Dropper12_NEW.lua
@@ -1,66 +1,64 @@
 --[[
 	Dropper 12 NEW - Diamond Blue Neon
-	Optimized with anti-stack
+	Uses DropperCore
 --]]
 
-local AntiStack = require(workspace:WaitForChild("DropperAntiStack"))
+local Core = require(game.ReplicatedStorage.Modules.DropperCore)
 
--- Setup collision groups
-AntiStack.SetupCollisionGroups()
+task.wait(1)
 
--- Setup player collisions
-game.Players.PlayerAdded:Connect(function(player)
-	player.CharacterAdded:Connect(AntiStack.SetupPlayerCollisions)
-end)
+-- Create template model
+local templateModel = Instance.new("Model")
+templateModel.Name = "Dropper12Template"
 
-for _, player in ipairs(game.Players:GetPlayers()) do
-	if player.Character then
-		AntiStack.SetupPlayerCollisions(player.Character)
-	end
+local mainPart = Instance.new("Part")
+mainPart.Name = "PrimaryPart"
+mainPart.Size = Vector3.new(0.4, 0.4, 0.4)
+mainPart.BrickColor = BrickColor.new("Cyan")
+mainPart.Material = Enum.Material.Neon
+mainPart.TopSurface = Enum.SurfaceType.Smooth
+mainPart.BottomSurface = Enum.SurfaceType.Smooth
+mainPart.Transparency = 0
+mainPart.Anchored = false
+mainPart.CanCollide = true
+mainPart.Parent = templateModel
+
+-- Set primary part
+templateModel.PrimaryPart = mainPart
+
+-- Store template
+local templateStorage = game.ReplicatedStorage:FindFirstChild("DropperTemplates")
+if not templateStorage then
+	templateStorage = Instance.new("Folder")
+	templateStorage.Name = "DropperTemplates"
+	templateStorage.Parent = game.ReplicatedStorage
 end
+templateModel.Parent = templateStorage
 
--- Wait for dependencies
-task.wait(2)
-local PartStorage = workspace:WaitForChild("PartStorage")
-local dropPart = script.Parent:WaitForChild("Drop")
+-- Run dropper
+Core.RunModel({
+	model = script.Parent,
+	partStorage = workspace:WaitForChild("PartStorage"),
+	templateModel = templateModel,
 
-local dropCount = 0
+	namePrefix = "Diamond12_",
+	dropGroup = "HelloKittyDrops12",
+	playerGroup = "Players",
 
-while true do
-	task.wait(0.35)
+	dropRate = 0.35,
+	cashValue = 500,
+	lifetime = 30,
+
+	scaleFactor = 1.0,
+	density = 0.3,
+	friction = 0.4,
+	elasticity = 0.1,
 	
-	-- Debounce check
-	if not AntiStack.CanDrop(0.3) then
-		continue
-	end
+	extraLower = 3.25,
+	fadeTime = 0.3,
 	
-	dropCount = dropCount + 1
-
-	-- Create part
-	local part = Instance.new("Part")
-	part.Name = "DiamondDrop12_" .. dropCount
-	part.BrickColor = BrickColor.new("Cyan")
-	part.Material = Enum.Material.Neon
-	part.FormFactor = "Custom"
-	part.Size = Vector3.new(0.4, 0.4, 0.4)
-	part.TopSurface = "Smooth"
-	part.BottomSurface = "Smooth"
-
-	-- Cash value
-	local cash = Instance.new("IntValue")
-	cash.Name = "Cash"
-	cash.Value = 500
-	cash.Parent = part
-
-	-- Apply anti-stack physics (with higher drop offset for small parts)
-	local dropPartClone = Instance.new("Part")
-	dropPartClone.CFrame = dropPart.CFrame - Vector3.new(0, 3.25, 0)
-	AntiStack.ApplyAntiStackPhysics(part, dropPartClone)
-	dropPartClone:Destroy()
-
-	-- Parent to storage
-	part.Parent = PartStorage
-
-	-- Schedule cleanup
-	AntiStack.ScheduleCleanup(part, 30)
-end
+	cashOn = "primary",
+	
+	collectorNames = {"Collector", "CollectorZone", "Receiver", "Sell", "SellPad"},
+	collectorTags = {"Collector", "SellZone"},
+})

--- a/Dropper13_NEW.lua
+++ b/Dropper13_NEW.lua
@@ -1,68 +1,76 @@
+--!strict
 --[[
-	Dropper 13 NEW - Epic Purple Crystal
-	Uses DropperCore
+	Dropper 13 NEW - Epic Purple Crystal with Sparkles (FIXED)
 --]]
 
-local Core = require(game.ReplicatedStorage.Modules.DropperCore)
+local PhysicsService = game:GetService("PhysicsService")
 
-task.wait(1)
+task.wait(2)
+local PartStorage = workspace:WaitForChild("PartStorage")
+local dropPart = script.Parent:WaitForChild("Drop")
 
--- Create template model
-local templateModel = Instance.new("Model")
-templateModel.Name = "Dropper13Template"
+local ORB_GROUP = "HelloKittyDrops13"
+local PLAYER_GROUP = "Players"
 
-local mainPart = Instance.new("Part")
-mainPart.Name = "PrimaryPart"
-mainPart.Size = Vector3.new(0.5, 0.5, 0.5)
-mainPart.BrickColor = BrickColor.new("Royal purple")
-mainPart.Material = Enum.Material.Neon
-mainPart.TopSurface = Enum.SurfaceType.Smooth
-mainPart.BottomSurface = Enum.SurfaceType.Smooth
-mainPart.Transparency = 0
-mainPart.Anchored = false
-mainPart.CanCollide = true
-mainPart.Parent = templateModel
+pcall(function()
+	PhysicsService:RegisterCollisionGroup(ORB_GROUP)
+	PhysicsService:RegisterCollisionGroup(PLAYER_GROUP)
+	PhysicsService:CollisionGroupSetCollidable(ORB_GROUP, PLAYER_GROUP, false)
+	PhysicsService:CollisionGroupSetCollidable(ORB_GROUP, ORB_GROUP, false)
+end)
 
--- Add sparkle effect
-local sparkle = Instance.new("Sparkles")
-sparkle.Parent = mainPart
-
--- Set primary part
-templateModel.PrimaryPart = mainPart
-
--- Store template
-local templateStorage = game.ReplicatedStorage:FindFirstChild("DropperTemplates")
-if not templateStorage then
-	templateStorage = Instance.new("Folder")
-	templateStorage.Name = "DropperTemplates"
-	templateStorage.Parent = game.ReplicatedStorage
+local function setupPlayer(character)
+	task.wait(0.1)
+	for _, part in ipairs(character:GetDescendants()) do
+		if part:IsA("BasePart") then
+			pcall(function() part.CollisionGroup = PLAYER_GROUP end)
+		end
+	end
 end
-templateModel.Parent = templateStorage
 
--- Run dropper
-Core.RunModel({
-	model = script.Parent,
-	partStorage = workspace:WaitForChild("PartStorage"),
-	templateModel = templateModel,
+game.Players.PlayerAdded:Connect(function(player)
+	player.CharacterAdded:Connect(setupPlayer)
+end)
 
-	namePrefix = "Crystal13_",
-	dropGroup = "HelloKittyDrops13",
-	playerGroup = "Players",
+for _, player in ipairs(game.Players:GetPlayers()) do
+	if player.Character then setupPlayer(player.Character) end
+end
 
-	dropRate = 0.3,
-	cashValue = 750,
-	lifetime = 35,
+local dropCount = 0
 
-	scaleFactor = 1.0,
-	density = 0.3,
-	friction = 0.4,
-	elasticity = 0.1,
-	
-	extraLower = 3.25,
-	fadeTime = 0.3,
-	
-	cashOn = "primary",
-	
-	collectorNames = {"Collector", "CollectorZone", "Receiver", "Sell", "SellPad"},
-	collectorTags = {"Collector", "SellZone"},
-})
+while true do
+	task.wait(0.3)
+	dropCount = dropCount + 1
+
+	local part = Instance.new("Part")
+	part.Name = "Crystal13_" .. dropCount
+	part.Size = Vector3.new(0.5, 0.5, 0.5)
+	part.BrickColor = BrickColor.new("Royal purple")
+	part.Material = Enum.Material.Neon
+	part.TopSurface = Enum.SurfaceType.Smooth
+	part.BottomSurface = Enum.SurfaceType.Smooth
+
+	-- Add sparkle effect
+	local sparkle = Instance.new("Sparkles")
+	sparkle.Parent = part
+
+	part.CanCollide = true
+	part.CanTouch = true
+	part.CanQuery = true
+	part.CollisionGroup = ORB_GROUP
+	part.CustomPhysicalProperties = PhysicalProperties.new(0.3, 0.4, 0.1, 1, 1)
+
+	local cash = Instance.new("IntValue")
+	cash.Name = "Cash"
+	cash.Value = 750
+	cash.Parent = part
+
+	local offsetX = math.random(-2, 2) * 0.1
+	local offsetZ = math.random(-2, 2) * 0.1
+	part.CFrame = (dropPart.CFrame - Vector3.new(offsetX, 3.25, offsetZ))
+	part.AssemblyLinearVelocity = Vector3.new(offsetX * 2, -10, offsetZ * 2)
+	part:SetAttribute("SpawnTime", os.clock())
+	part.Parent = PartStorage
+
+	task.delay(35, function() if part and part.Parent then part:Destroy() end end)
+end

--- a/Dropper13_NEW.lua
+++ b/Dropper13_NEW.lua
@@ -1,0 +1,70 @@
+--[[
+	Dropper 13 NEW - Epic Purple Crystal
+	Optimized with anti-stack
+--]]
+
+local AntiStack = require(workspace:WaitForChild("DropperAntiStack"))
+
+-- Setup collision groups
+AntiStack.SetupCollisionGroups()
+
+-- Setup player collisions
+game.Players.PlayerAdded:Connect(function(player)
+	player.CharacterAdded:Connect(AntiStack.SetupPlayerCollisions)
+end)
+
+for _, player in ipairs(game.Players:GetPlayers()) do
+	if player.Character then
+		AntiStack.SetupPlayerCollisions(player.Character)
+	end
+end
+
+-- Wait for dependencies
+task.wait(2)
+local PartStorage = workspace:WaitForChild("PartStorage")
+local dropPart = script.Parent:WaitForChild("Drop")
+
+local dropCount = 0
+
+while true do
+	task.wait(0.3)
+	
+	-- Debounce check
+	if not AntiStack.CanDrop(0.25) then
+		continue
+	end
+	
+	dropCount = dropCount + 1
+
+	-- Create part
+	local part = Instance.new("Part")
+	part.Name = "CrystalDrop13_" .. dropCount
+	part.BrickColor = BrickColor.new("Royal purple")
+	part.Material = Enum.Material.Neon
+	part.FormFactor = "Custom"
+	part.Size = Vector3.new(0.5, 0.5, 0.5)
+	part.TopSurface = "Smooth"
+	part.BottomSurface = "Smooth"
+
+	-- Add sparkle effect
+	local sparkle = Instance.new("Sparkles")
+	sparkle.Parent = part
+
+	-- Cash value
+	local cash = Instance.new("IntValue")
+	cash.Name = "Cash"
+	cash.Value = 750
+	cash.Parent = part
+
+	-- Apply anti-stack physics (with higher drop offset for small parts)
+	local dropPartClone = Instance.new("Part")
+	dropPartClone.CFrame = dropPart.CFrame - Vector3.new(0, 3.25, 0)
+	AntiStack.ApplyAntiStackPhysics(part, dropPartClone)
+	dropPartClone:Destroy()
+
+	-- Parent to storage
+	part.Parent = PartStorage
+
+	-- Schedule cleanup
+	AntiStack.ScheduleCleanup(part, 35)
+end

--- a/Dropper13_NEW.lua
+++ b/Dropper13_NEW.lua
@@ -1,70 +1,68 @@
 --[[
 	Dropper 13 NEW - Epic Purple Crystal
-	Optimized with anti-stack
+	Uses DropperCore
 --]]
 
-local AntiStack = require(workspace:WaitForChild("DropperAntiStack"))
+local Core = require(game.ReplicatedStorage.Modules.DropperCore)
 
--- Setup collision groups
-AntiStack.SetupCollisionGroups()
+task.wait(1)
 
--- Setup player collisions
-game.Players.PlayerAdded:Connect(function(player)
-	player.CharacterAdded:Connect(AntiStack.SetupPlayerCollisions)
-end)
+-- Create template model
+local templateModel = Instance.new("Model")
+templateModel.Name = "Dropper13Template"
 
-for _, player in ipairs(game.Players:GetPlayers()) do
-	if player.Character then
-		AntiStack.SetupPlayerCollisions(player.Character)
-	end
+local mainPart = Instance.new("Part")
+mainPart.Name = "PrimaryPart"
+mainPart.Size = Vector3.new(0.5, 0.5, 0.5)
+mainPart.BrickColor = BrickColor.new("Royal purple")
+mainPart.Material = Enum.Material.Neon
+mainPart.TopSurface = Enum.SurfaceType.Smooth
+mainPart.BottomSurface = Enum.SurfaceType.Smooth
+mainPart.Transparency = 0
+mainPart.Anchored = false
+mainPart.CanCollide = true
+mainPart.Parent = templateModel
+
+-- Add sparkle effect
+local sparkle = Instance.new("Sparkles")
+sparkle.Parent = mainPart
+
+-- Set primary part
+templateModel.PrimaryPart = mainPart
+
+-- Store template
+local templateStorage = game.ReplicatedStorage:FindFirstChild("DropperTemplates")
+if not templateStorage then
+	templateStorage = Instance.new("Folder")
+	templateStorage.Name = "DropperTemplates"
+	templateStorage.Parent = game.ReplicatedStorage
 end
+templateModel.Parent = templateStorage
 
--- Wait for dependencies
-task.wait(2)
-local PartStorage = workspace:WaitForChild("PartStorage")
-local dropPart = script.Parent:WaitForChild("Drop")
+-- Run dropper
+Core.RunModel({
+	model = script.Parent,
+	partStorage = workspace:WaitForChild("PartStorage"),
+	templateModel = templateModel,
 
-local dropCount = 0
+	namePrefix = "Crystal13_",
+	dropGroup = "HelloKittyDrops13",
+	playerGroup = "Players",
 
-while true do
-	task.wait(0.3)
+	dropRate = 0.3,
+	cashValue = 750,
+	lifetime = 35,
+
+	scaleFactor = 1.0,
+	density = 0.3,
+	friction = 0.4,
+	elasticity = 0.1,
 	
-	-- Debounce check
-	if not AntiStack.CanDrop(0.25) then
-		continue
-	end
+	extraLower = 3.25,
+	fadeTime = 0.3,
 	
-	dropCount = dropCount + 1
-
-	-- Create part
-	local part = Instance.new("Part")
-	part.Name = "CrystalDrop13_" .. dropCount
-	part.BrickColor = BrickColor.new("Royal purple")
-	part.Material = Enum.Material.Neon
-	part.FormFactor = "Custom"
-	part.Size = Vector3.new(0.5, 0.5, 0.5)
-	part.TopSurface = "Smooth"
-	part.BottomSurface = "Smooth"
-
-	-- Add sparkle effect
-	local sparkle = Instance.new("Sparkles")
-	sparkle.Parent = part
-
-	-- Cash value
-	local cash = Instance.new("IntValue")
-	cash.Name = "Cash"
-	cash.Value = 750
-	cash.Parent = part
-
-	-- Apply anti-stack physics (with higher drop offset for small parts)
-	local dropPartClone = Instance.new("Part")
-	dropPartClone.CFrame = dropPart.CFrame - Vector3.new(0, 3.25, 0)
-	AntiStack.ApplyAntiStackPhysics(part, dropPartClone)
-	dropPartClone:Destroy()
-
-	-- Parent to storage
-	part.Parent = PartStorage
-
-	-- Schedule cleanup
-	AntiStack.ScheduleCleanup(part, 35)
-end
+	cashOn = "primary",
+	
+	collectorNames = {"Collector", "CollectorZone", "Receiver", "Sell", "SellPad"},
+	collectorTags = {"Collector", "SellZone"},
+})

--- a/Dropper1_Fixed.lua
+++ b/Dropper1_Fixed.lua
@@ -10,7 +10,7 @@ Core.RunModel({
 	templateModel = RS:WaitForChild("HelloKittyPL"),
 
 	namePrefix    = "Drop_",
-	dropGroup     = "Drops",
+	dropGroup     = "HelloKittyDrops1",
 	playerGroup   = "Players",
 	dropRate      = 1.2,
 	cashValue     = 10,

--- a/Dropper1_NEW.lua
+++ b/Dropper1_NEW.lua
@@ -1,4 +1,5 @@
--- Dropper 1 NEW - Using DropperCore (Already Optimized)
+--!strict
+-- Dropper 1 NEW - Using DropperCore (FIXED COLLISION)
 local RS = game:GetService("ReplicatedStorage")
 local Core = require(RS:WaitForChild("Modules"):WaitForChild("DropperCore"))
 
@@ -9,23 +10,22 @@ Core.RunModel({
 	partStorage   = workspace:WaitForChild("PartStorage"),
 	templateModel = RS:WaitForChild("HelloKittyPL"),
 
-	namePrefix    = "Drop_",
+	namePrefix    = "HK1Drop_",
 	dropGroup     = "HelloKittyDrops1",
 	playerGroup   = "Players",
-	dropRate      = 1.2,
+	dropRate      = 1.0,
 	cashValue     = 10,
 	lifetime      = 120,
 
 	scaleFactor   = 0.9,
-	extraLower    = 0.45,
+	extraLower    = 1.0,
 	fadeTime      = 0.35,
 	yawDegrees    = -90,
-	prewarm       = 8,
 	cashOn        = "primary",
 
-	density       = 0.7,
-	friction      = 0.3,
-	elasticity    = 0.05,
+	density       = 0.3,
+	friction      = 0.5,
+	elasticity    = 0.2,
 
 	collectorNames = { "Collector", "CollectorZone", "Receiver", "Sell", "SellPad" },
 	collectorTags  = { "Collector", "SellZone" },

--- a/Dropper1_NEW.lua
+++ b/Dropper1_NEW.lua
@@ -1,0 +1,32 @@
+-- Dropper 1 NEW - Using DropperCore (Already Optimized)
+local RS = game:GetService("ReplicatedStorage")
+local Core = require(RS:WaitForChild("Modules"):WaitForChild("DropperCore"))
+
+task.wait(1)
+
+Core.RunModel({
+	model         = script.Parent,
+	partStorage   = workspace:WaitForChild("PartStorage"),
+	templateModel = RS:WaitForChild("HelloKittyPL"),
+
+	namePrefix    = "Drop_",
+	dropGroup     = "HelloKittyDrops1",
+	playerGroup   = "Players",
+	dropRate      = 1.2,
+	cashValue     = 10,
+	lifetime      = 120,
+
+	scaleFactor   = 0.9,
+	extraLower    = 0.45,
+	fadeTime      = 0.35,
+	yawDegrees    = -90,
+	prewarm       = 8,
+	cashOn        = "primary",
+
+	density       = 0.7,
+	friction      = 0.3,
+	elasticity    = 0.05,
+
+	collectorNames = { "Collector", "CollectorZone", "Receiver", "Sell", "SellPad" },
+	collectorTags  = { "Collector", "SellZone" },
+})

--- a/Dropper1_NEW.lua
+++ b/Dropper1_NEW.lua
@@ -1,32 +1,153 @@
 --!strict
--- Dropper 1 NEW - Using DropperCore (FIXED COLLISION)
-local RS = game:GetService("ReplicatedStorage")
-local Core = require(RS:WaitForChild("Modules"):WaitForChild("DropperCore"))
+--[[
+	Dropper 1 NEW - HelloKitty Style (FIXED LIKE CINNAMOROLL)
+	Collides with conveyor/ground but NOT players or other drops
+--]]
 
-task.wait(1)
+local TweenService = game:GetService("TweenService")
+local Debris = game:GetService("Debris")
+local PhysicsService = game:GetService("PhysicsService")
 
-Core.RunModel({
-	model         = script.Parent,
-	partStorage   = workspace:WaitForChild("PartStorage"),
-	templateModel = RS:WaitForChild("HelloKittyPL"),
+-- Wait for PartStorage
+task.wait(2)
+local PartStorage = workspace:WaitForChild("PartStorage")
 
-	namePrefix    = "HK1Drop_",
-	dropGroup     = "HelloKittyDrops1",
-	playerGroup   = "Players",
-	dropRate      = 1.0,
-	cashValue     = 10,
-	lifetime      = 120,
+-- Find the Drop part
+local dropPart = script.Parent:WaitForChild("Drop")
 
-	scaleFactor   = 0.9,
-	extraLower    = 1.0,
-	fadeTime      = 0.35,
-	yawDegrees    = -90,
-	cashOn        = "primary",
+-- Create collision groups
+local ORB_GROUP = "HelloKittyDrops1"
+local PLAYER_GROUP = "Players"
 
-	density       = 0.3,
-	friction      = 0.5,
-	elasticity    = 0.2,
+pcall(function()
+	PhysicsService:RegisterCollisionGroup(ORB_GROUP)
+	PhysicsService:RegisterCollisionGroup(PLAYER_GROUP)
+	-- Orbs don't collide with players
+	PhysicsService:CollisionGroupSetCollidable(ORB_GROUP, PLAYER_GROUP, false)
+	-- Orbs don't collide with each other
+	PhysicsService:CollisionGroupSetCollidable(ORB_GROUP, ORB_GROUP, false)
+end)
 
-	collectorNames = { "Collector", "CollectorZone", "Receiver", "Sell", "SellPad" },
-	collectorTags  = { "Collector", "SellZone" },
-})
+-- Setup player collision groups
+local function setupPlayer(character)
+	task.wait(0.1)
+	for _, part in ipairs(character:GetDescendants()) do
+		if part:IsA("BasePart") then
+			pcall(function()
+				part.CollisionGroup = PLAYER_GROUP
+			end)
+		end
+	end
+end
+
+game.Players.PlayerAdded:Connect(function(player)
+	player.CharacterAdded:Connect(setupPlayer)
+end)
+
+-- Setup existing players
+for _, player in ipairs(game.Players:GetPlayers()) do
+	if player.Character then
+		setupPlayer(player.Character)
+	end
+end
+
+local dropCount = 0
+
+while true do
+	task.wait(1.0) -- Drop rate
+
+	dropCount = dropCount + 1
+
+	-- Create drop
+	local orb = Instance.new("Part")
+	orb.Name = "HK1Drop_" .. dropCount
+	orb.Size = Vector3.new(2, 2, 2)
+	orb.Material = Enum.Material.SmoothPlastic
+	orb.TopSurface = Enum.SurfaceType.Smooth
+	orb.BottomSurface = Enum.SurfaceType.Smooth
+	orb.Color = Color3.new(1, 1, 1)
+	orb.Transparency = 0.7 -- Start faded for animation
+
+	-- COLLISION: On for world, off for players/other drops
+	orb.CanCollide = true -- Collides with conveyor!
+	orb.CanTouch = true
+	orb.CanQuery = true
+
+	-- Set collision group (NO pcall - direct assignment)
+	orb.CollisionGroup = ORB_GROUP
+
+	-- Light physics
+	orb.CustomPhysicalProperties = PhysicalProperties.new(
+		0.3,  -- Light density
+		0.5,  -- Medium friction
+		0.2,  -- Low bounce
+		1, 1
+	)
+
+	-- Cash value - CRITICAL!
+	local cash = Instance.new("IntValue")
+	cash.Name = "Cash"
+	cash.Value = 10
+	cash.Parent = orb
+
+	-- Add light
+	local pointLight = Instance.new("PointLight")
+	pointLight.Brightness = 0.6
+	pointLight.Range = 4
+	pointLight.Color = Color3.new(1, 1, 1)
+	pointLight.Parent = orb
+
+	-- Position with small random offset
+	local offsetX = math.random(-2, 2) * 0.15
+	local offsetZ = math.random(-2, 2) * 0.15
+	orb.CFrame = (dropPart.CFrame - Vector3.new(offsetX, 2, offsetZ)) * CFrame.Angles(0, math.rad(math.random(-45, 45)), 0)
+
+	-- Gentle drop velocity
+	orb.AssemblyLinearVelocity = Vector3.new(offsetX * 2, -10, offsetZ * 2)
+
+	-- Set spawn time
+	orb:SetAttribute("SpawnTime", os.clock())
+
+	-- Parent to storage
+	orb.Parent = PartStorage
+
+	-- Smooth fade-in
+	local fadeTween = TweenService:Create(orb,
+		TweenInfo.new(0.5, Enum.EasingStyle.Quad, Enum.EasingDirection.Out),
+		{Transparency = 0}
+	)
+	fadeTween:Play()
+
+	-- Light flash
+	pointLight.Brightness = 1.5
+	TweenService:Create(pointLight,
+		TweenInfo.new(0.6, Enum.EasingStyle.Quad, Enum.EasingDirection.Out),
+		{Brightness = 0.6}
+	):Play()
+
+	-- Spawn ring effect
+	local spawnRing = Instance.new("ParticleEmitter")
+	spawnRing.Texture = "rbxassetid://262979222"
+	spawnRing.Rate = 0
+	spawnRing.Speed = NumberRange.new(0)
+	spawnRing.Lifetime = NumberRange.new(0.3)
+	spawnRing.Size = NumberSequence.new({
+		NumberSequenceKeypoint.new(0, 0.1),
+		NumberSequenceKeypoint.new(1, 2)
+	})
+	spawnRing.Transparency = NumberSequence.new({
+		NumberSequenceKeypoint.new(0, 0.3),
+		NumberSequenceKeypoint.new(1, 1)
+	})
+	spawnRing.Color = ColorSequence.new(Color3.new(1, 1, 1))
+	spawnRing.Parent = orb
+	spawnRing:Emit(1)
+	Debris:AddItem(spawnRing, 1)
+
+	-- Cleanup after 120 seconds
+	task.delay(120, function()
+		if orb and orb.Parent then
+			orb:Destroy()
+		end
+	end)
+end

--- a/Dropper2_NEW.lua
+++ b/Dropper2_NEW.lua
@@ -1,135 +1,79 @@
 --[[
-	Cinnamoroll Dropper 2 NEW - Fixed Version
-	Optimized with anti-stack and proper collision handling
+	Dropper 2 NEW - Cinnamoroll Style
+	Uses DropperCore
 --]]
 
-local TweenService = game:GetService("TweenService")
-local Debris = game:GetService("Debris")
-local AntiStack = require(workspace:WaitForChild("DropperAntiStack"))
+local Core = require(game.ReplicatedStorage.Modules.DropperCore)
 
--- Setup collision groups
-AntiStack.SetupCollisionGroups()
+task.wait(1)
 
--- Setup player collisions
-game.Players.PlayerAdded:Connect(function(player)
-	player.CharacterAdded:Connect(AntiStack.SetupPlayerCollisions)
-end)
+-- Create template model
+local templateModel = Instance.new("Model")
+templateModel.Name = "Dropper2Template"
 
-for _, player in ipairs(game.Players:GetPlayers()) do
-	if player.Character then
-		AntiStack.SetupPlayerCollisions(player.Character)
-	end
+local mainPart = Instance.new("Part")
+mainPart.Name = "PrimaryPart"
+mainPart.Size = Vector3.new(2, 2, 2)
+mainPart.Color = Color3.new(1, 1, 1)
+mainPart.Material = Enum.Material.SmoothPlastic
+mainPart.TopSurface = Enum.SurfaceType.Smooth
+mainPart.BottomSurface = Enum.SurfaceType.Smooth
+mainPart.Transparency = 0
+mainPart.Anchored = false
+mainPart.CanCollide = true
+mainPart.Parent = templateModel
+
+-- Add mesh
+local mesh = Instance.new("SpecialMesh")
+mesh.MeshType = Enum.MeshType.FileMesh
+mesh.MeshId = "rbxassetid://114684643919279"
+mesh.TextureId = "rbxassetid://136339015269351"
+mesh.Scale = Vector3.new(2, 2, 2)
+mesh.Parent = mainPart
+
+-- Add light
+local light = Instance.new("PointLight")
+light.Brightness = 0.6
+light.Range = 4
+light.Color = Color3.new(1, 1, 1)
+light.Parent = mainPart
+
+-- Set primary part
+templateModel.PrimaryPart = mainPart
+
+-- Store template
+local templateStorage = game.ReplicatedStorage:FindFirstChild("DropperTemplates")
+if not templateStorage then
+	templateStorage = Instance.new("Folder")
+	templateStorage.Name = "DropperTemplates"
+	templateStorage.Parent = game.ReplicatedStorage
 end
+templateModel.Parent = templateStorage
 
--- Wait for dependencies
-task.wait(2)
-local PartStorage = workspace:WaitForChild("PartStorage")
-local dropPart = script.Parent:WaitForChild("Drop")
+-- Run dropper with DropperCore
+Core.RunModel({
+	model = script.Parent,
+	partStorage = workspace:WaitForChild("PartStorage"),
+	templateModel = templateModel,
 
-local orbCount = 0
+	namePrefix = "Cinnamoroll2_",
+	dropGroup = "HelloKittyDrops2",
+	playerGroup = "Players",
 
-while true do
-	task.wait(1)
+	dropRate = 1.0,
+	cashValue = 15,
+	lifetime = 180,
+
+	scaleFactor = 1.0,
+	density = 0.2,
+	friction = 0.3,
+	elasticity = 0.1,
 	
-	-- Debounce check
-	if not AntiStack.CanDrop(0.9) then
-		continue
-	end
+	extraLower = 1.75,
+	fadeTime = 0.6,
 	
-	orbCount = orbCount + 1
-
-	-- Create the drop
-	local orb = Instance.new("Part")
-	orb.Name = "CinnamorollMesh_" .. orbCount
-	orb.Size = Vector3.new(2, 2, 2)
-	orb.Material = Enum.Material.SmoothPlastic
-	orb.TopSurface = Enum.SurfaceType.Smooth
-	orb.BottomSurface = Enum.SurfaceType.Smooth
-	orb.Color = Color3.new(1, 1, 1)
-	orb.Transparency = 0.7
-
-	-- Add mesh
-	local mesh = Instance.new("SpecialMesh")
-	mesh.MeshType = Enum.MeshType.FileMesh
-	mesh.MeshId = "rbxassetid://114684643919279"
-	mesh.TextureId = "rbxassetid://136339015269351"
-	mesh.Scale = Vector3.new(0.5, 0.5, 0.5)
-	mesh.Parent = orb
-
-	-- Cash value
-	local cash = Instance.new("IntValue")
-	cash.Name = "Cash"
-	cash.Value = 15
-	cash.Parent = orb
-
-	-- Reduced glow
-	local pointLight = Instance.new("PointLight")
-	pointLight.Brightness = 0.6
-	pointLight.Range = 4
-	pointLight.Color = Color3.new(1, 1, 1)
-	pointLight.Parent = orb
-
-	-- Simple sparkles
-	local sparkle = Instance.new("ParticleEmitter")
-	sparkle.Texture = "rbxasset://textures/particles/sparkles_main.dds"
-	sparkle.Rate = 3
-	sparkle.Lifetime = NumberRange.new(0.5, 1)
-	sparkle.Speed = NumberRange.new(0.5, 1.5)
-	sparkle.SpreadAngle = Vector2.new(90, 90)
-	sparkle.LightEmission = 0.8
-	sparkle.LightInfluence = 0
-	sparkle.Size = NumberSequence.new{
-		NumberSequenceKeypoint.new(0, 0.2),
-		NumberSequenceKeypoint.new(1, 0)
-	}
-	sparkle.Color = ColorSequence.new(Color3.new(1, 1, 1))
-	sparkle.Parent = orb
-
-	-- Apply anti-stack physics
-	AntiStack.ApplyAntiStackPhysics(orb, dropPart)
+	cashOn = "primary",
 	
-	orb.CFrame = orb.CFrame * CFrame.Angles(math.rad(180), math.rad(270), 0)
-
-	-- Parent to storage
-	orb.Parent = PartStorage
-
-	-- Smooth animations
-	TweenService:Create(orb,
-		TweenInfo.new(0.5, Enum.EasingStyle.Quad, Enum.EasingDirection.Out),
-		{Transparency = 0}
-	):Play()
-
-	TweenService:Create(mesh,
-		TweenInfo.new(0.5, Enum.EasingStyle.Back, Enum.EasingDirection.Out),
-		{Scale = Vector3.new(2, 2, 2)}
-	):Play()
-
-	-- Light flash
-	pointLight.Brightness = 1.5
-	TweenService:Create(pointLight,
-		TweenInfo.new(0.6, Enum.EasingStyle.Quad, Enum.EasingDirection.Out),
-		{Brightness = 0.6}
-	):Play()
-
-	-- Simple spawn puff
-	local spawnPuff = Instance.new("ParticleEmitter")
-	spawnPuff.Texture = "rbxassetid://262979222"
-	spawnPuff.Rate = 0
-	spawnPuff.Speed = NumberRange.new(0)
-	spawnPuff.Lifetime = NumberRange.new(0.3)
-	spawnPuff.Size = NumberSequence.new({
-		NumberSequenceKeypoint.new(0, 0.1),
-		NumberSequenceKeypoint.new(1, 2)
-	})
-	spawnPuff.Transparency = NumberSequence.new({
-		NumberSequenceKeypoint.new(0, 0.3),
-		NumberSequenceKeypoint.new(1, 1)
-	})
-	spawnPuff.Color = ColorSequence.new(Color3.new(1, 1, 1))
-	spawnPuff.Parent = orb
-	spawnPuff:Emit(1)
-	Debris:AddItem(spawnPuff, 1)
-
-	-- Schedule cleanup
-	AntiStack.ScheduleCleanup(orb, 180)
-end
+	collectorNames = {"Collector", "CollectorZone", "Receiver", "Sell", "SellPad"},
+	collectorTags = {"Collector", "SellZone"},
+})

--- a/Dropper2_NEW.lua
+++ b/Dropper2_NEW.lua
@@ -1,79 +1,95 @@
+--!strict
 --[[
-	Dropper 2 NEW - Cinnamoroll Style
-	Uses DropperCore
+	Dropper 2 NEW - Cinnamoroll Style (FIXED)
+	Collides with conveyor/ground but NOT players or other drops
 --]]
 
-local Core = require(game.ReplicatedStorage.Modules.DropperCore)
+local TweenService = game:GetService("TweenService")
+local Debris = game:GetService("Debris")
+local PhysicsService = game:GetService("PhysicsService")
 
-task.wait(1)
+task.wait(2)
+local PartStorage = workspace:WaitForChild("PartStorage")
+local dropPart = script.Parent:WaitForChild("Drop")
 
--- Create template model
-local templateModel = Instance.new("Model")
-templateModel.Name = "Dropper2Template"
+local ORB_GROUP = "HelloKittyDrops2"
+local PLAYER_GROUP = "Players"
 
-local mainPart = Instance.new("Part")
-mainPart.Name = "PrimaryPart"
-mainPart.Size = Vector3.new(2, 2, 2)
-mainPart.Color = Color3.new(1, 1, 1)
-mainPart.Material = Enum.Material.SmoothPlastic
-mainPart.TopSurface = Enum.SurfaceType.Smooth
-mainPart.BottomSurface = Enum.SurfaceType.Smooth
-mainPart.Transparency = 0
-mainPart.Anchored = false
-mainPart.CanCollide = true
-mainPart.Parent = templateModel
+pcall(function()
+	PhysicsService:RegisterCollisionGroup(ORB_GROUP)
+	PhysicsService:RegisterCollisionGroup(PLAYER_GROUP)
+	PhysicsService:CollisionGroupSetCollidable(ORB_GROUP, PLAYER_GROUP, false)
+	PhysicsService:CollisionGroupSetCollidable(ORB_GROUP, ORB_GROUP, false)
+end)
 
--- Add mesh
-local mesh = Instance.new("SpecialMesh")
-mesh.MeshType = Enum.MeshType.FileMesh
-mesh.MeshId = "rbxassetid://114684643919279"
-mesh.TextureId = "rbxassetid://136339015269351"
-mesh.Scale = Vector3.new(2, 2, 2)
-mesh.Parent = mainPart
-
--- Add light
-local light = Instance.new("PointLight")
-light.Brightness = 0.6
-light.Range = 4
-light.Color = Color3.new(1, 1, 1)
-light.Parent = mainPart
-
--- Set primary part
-templateModel.PrimaryPart = mainPart
-
--- Store template
-local templateStorage = game.ReplicatedStorage:FindFirstChild("DropperTemplates")
-if not templateStorage then
-	templateStorage = Instance.new("Folder")
-	templateStorage.Name = "DropperTemplates"
-	templateStorage.Parent = game.ReplicatedStorage
+local function setupPlayer(character)
+	task.wait(0.1)
+	for _, part in ipairs(character:GetDescendants()) do
+		if part:IsA("BasePart") then
+			pcall(function() part.CollisionGroup = PLAYER_GROUP end)
+		end
+	end
 end
-templateModel.Parent = templateStorage
 
--- Run dropper with DropperCore
-Core.RunModel({
-	model = script.Parent,
-	partStorage = workspace:WaitForChild("PartStorage"),
-	templateModel = templateModel,
+game.Players.PlayerAdded:Connect(function(player)
+	player.CharacterAdded:Connect(setupPlayer)
+end)
 
-	namePrefix = "Cinnamoroll2_",
-	dropGroup = "HelloKittyDrops2",
-	playerGroup = "Players",
+for _, player in ipairs(game.Players:GetPlayers()) do
+	if player.Character then setupPlayer(player.Character) end
+end
 
-	dropRate = 1.0,
-	cashValue = 15,
-	lifetime = 180,
+local dropCount = 0
 
-	scaleFactor = 1.0,
-	density = 0.2,
-	friction = 0.3,
-	elasticity = 0.1,
-	
-	extraLower = 1.75,
-	fadeTime = 0.6,
-	
-	cashOn = "primary",
-	
-	collectorNames = {"Collector", "CollectorZone", "Receiver", "Sell", "SellPad"},
-	collectorTags = {"Collector", "SellZone"},
-})
+while true do
+	task.wait(1.0)
+	dropCount = dropCount + 1
+
+	local orb = Instance.new("Part")
+	orb.Name = "Cinnamoroll2_" .. dropCount
+	orb.Size = Vector3.new(2, 2, 2)
+	orb.Material = Enum.Material.SmoothPlastic
+	orb.TopSurface = Enum.SurfaceType.Smooth
+	orb.BottomSurface = Enum.SurfaceType.Smooth
+	orb.Color = Color3.new(1, 1, 1)
+	orb.Transparency = 0.7
+
+	local mesh = Instance.new("SpecialMesh")
+	mesh.MeshType = Enum.MeshType.FileMesh
+	mesh.MeshId = "rbxassetid://114684643919279"
+	mesh.TextureId = "rbxassetid://136339015269351"
+	mesh.Scale = Vector3.new(0.5, 0.5, 0.5)
+	mesh.Parent = orb
+
+	orb.CanCollide = true
+	orb.CanTouch = true
+	orb.CanQuery = true
+	orb.CollisionGroup = ORB_GROUP
+	orb.CustomPhysicalProperties = PhysicalProperties.new(0.2, 0.3, 0.1, 1, 1)
+
+	local cash = Instance.new("IntValue")
+	cash.Name = "Cash"
+	cash.Value = 15
+	cash.Parent = orb
+
+	local pointLight = Instance.new("PointLight")
+	pointLight.Brightness = 0.6
+	pointLight.Range = 4
+	pointLight.Color = Color3.new(1, 1, 1)
+	pointLight.Parent = orb
+
+	local offsetX = math.random(-2, 2) * 0.1
+	local offsetZ = math.random(-2, 2) * 0.1
+	orb.CFrame = (dropPart.CFrame - Vector3.new(offsetX, 1.75, offsetZ)) * CFrame.Angles(math.rad(180), math.rad(270), 0)
+	orb.AssemblyLinearVelocity = Vector3.new(offsetX * 2, -10, offsetZ * 2)
+	orb:SetAttribute("SpawnTime", os.clock())
+	orb.Parent = PartStorage
+
+	TweenService:Create(orb, TweenInfo.new(0.5, Enum.EasingStyle.Quad, Enum.EasingDirection.Out), {Transparency = 0}):Play()
+	TweenService:Create(mesh, TweenInfo.new(0.5, Enum.EasingStyle.Back, Enum.EasingDirection.Out), {Scale = Vector3.new(2, 2, 2)}):Play()
+
+	pointLight.Brightness = 1.5
+	TweenService:Create(pointLight, TweenInfo.new(0.6, Enum.EasingStyle.Quad, Enum.EasingDirection.Out), {Brightness = 0.6}):Play()
+
+	task.delay(180, function() if orb and orb.Parent then orb:Destroy() end end)
+end

--- a/Dropper2_NEW.lua
+++ b/Dropper2_NEW.lua
@@ -1,0 +1,135 @@
+--[[
+	Cinnamoroll Dropper 2 NEW - Fixed Version
+	Optimized with anti-stack and proper collision handling
+--]]
+
+local TweenService = game:GetService("TweenService")
+local Debris = game:GetService("Debris")
+local AntiStack = require(workspace:WaitForChild("DropperAntiStack"))
+
+-- Setup collision groups
+AntiStack.SetupCollisionGroups()
+
+-- Setup player collisions
+game.Players.PlayerAdded:Connect(function(player)
+	player.CharacterAdded:Connect(AntiStack.SetupPlayerCollisions)
+end)
+
+for _, player in ipairs(game.Players:GetPlayers()) do
+	if player.Character then
+		AntiStack.SetupPlayerCollisions(player.Character)
+	end
+end
+
+-- Wait for dependencies
+task.wait(2)
+local PartStorage = workspace:WaitForChild("PartStorage")
+local dropPart = script.Parent:WaitForChild("Drop")
+
+local orbCount = 0
+
+while true do
+	task.wait(1)
+	
+	-- Debounce check
+	if not AntiStack.CanDrop(0.9) then
+		continue
+	end
+	
+	orbCount = orbCount + 1
+
+	-- Create the drop
+	local orb = Instance.new("Part")
+	orb.Name = "CinnamorollMesh_" .. orbCount
+	orb.Size = Vector3.new(2, 2, 2)
+	orb.Material = Enum.Material.SmoothPlastic
+	orb.TopSurface = Enum.SurfaceType.Smooth
+	orb.BottomSurface = Enum.SurfaceType.Smooth
+	orb.Color = Color3.new(1, 1, 1)
+	orb.Transparency = 0.7
+
+	-- Add mesh
+	local mesh = Instance.new("SpecialMesh")
+	mesh.MeshType = Enum.MeshType.FileMesh
+	mesh.MeshId = "rbxassetid://114684643919279"
+	mesh.TextureId = "rbxassetid://136339015269351"
+	mesh.Scale = Vector3.new(0.5, 0.5, 0.5)
+	mesh.Parent = orb
+
+	-- Cash value
+	local cash = Instance.new("IntValue")
+	cash.Name = "Cash"
+	cash.Value = 15
+	cash.Parent = orb
+
+	-- Reduced glow
+	local pointLight = Instance.new("PointLight")
+	pointLight.Brightness = 0.6
+	pointLight.Range = 4
+	pointLight.Color = Color3.new(1, 1, 1)
+	pointLight.Parent = orb
+
+	-- Simple sparkles
+	local sparkle = Instance.new("ParticleEmitter")
+	sparkle.Texture = "rbxasset://textures/particles/sparkles_main.dds"
+	sparkle.Rate = 3
+	sparkle.Lifetime = NumberRange.new(0.5, 1)
+	sparkle.Speed = NumberRange.new(0.5, 1.5)
+	sparkle.SpreadAngle = Vector2.new(90, 90)
+	sparkle.LightEmission = 0.8
+	sparkle.LightInfluence = 0
+	sparkle.Size = NumberSequence.new{
+		NumberSequenceKeypoint.new(0, 0.2),
+		NumberSequenceKeypoint.new(1, 0)
+	}
+	sparkle.Color = ColorSequence.new(Color3.new(1, 1, 1))
+	sparkle.Parent = orb
+
+	-- Apply anti-stack physics
+	AntiStack.ApplyAntiStackPhysics(orb, dropPart)
+	
+	orb.CFrame = orb.CFrame * CFrame.Angles(math.rad(180), math.rad(270), 0)
+
+	-- Parent to storage
+	orb.Parent = PartStorage
+
+	-- Smooth animations
+	TweenService:Create(orb,
+		TweenInfo.new(0.5, Enum.EasingStyle.Quad, Enum.EasingDirection.Out),
+		{Transparency = 0}
+	):Play()
+
+	TweenService:Create(mesh,
+		TweenInfo.new(0.5, Enum.EasingStyle.Back, Enum.EasingDirection.Out),
+		{Scale = Vector3.new(2, 2, 2)}
+	):Play()
+
+	-- Light flash
+	pointLight.Brightness = 1.5
+	TweenService:Create(pointLight,
+		TweenInfo.new(0.6, Enum.EasingStyle.Quad, Enum.EasingDirection.Out),
+		{Brightness = 0.6}
+	):Play()
+
+	-- Simple spawn puff
+	local spawnPuff = Instance.new("ParticleEmitter")
+	spawnPuff.Texture = "rbxassetid://262979222"
+	spawnPuff.Rate = 0
+	spawnPuff.Speed = NumberRange.new(0)
+	spawnPuff.Lifetime = NumberRange.new(0.3)
+	spawnPuff.Size = NumberSequence.new({
+		NumberSequenceKeypoint.new(0, 0.1),
+		NumberSequenceKeypoint.new(1, 2)
+	})
+	spawnPuff.Transparency = NumberSequence.new({
+		NumberSequenceKeypoint.new(0, 0.3),
+		NumberSequenceKeypoint.new(1, 1)
+	})
+	spawnPuff.Color = ColorSequence.new(Color3.new(1, 1, 1))
+	spawnPuff.Parent = orb
+	spawnPuff:Emit(1)
+	Debris:AddItem(spawnPuff, 1)
+
+	-- Schedule cleanup
+	AntiStack.ScheduleCleanup(orb, 180)
+end

--- a/Dropper3_NEW.lua
+++ b/Dropper3_NEW.lua
@@ -1,0 +1,145 @@
+--[[
+	Hello Kitty Dropper 3 NEW - Premium Style Fixed
+	Optimized with anti-stack and rotation lock
+--]]
+
+local TweenService = game:GetService("TweenService")
+local Debris = game:GetService("Debris")
+local AntiStack = require(workspace:WaitForChild("DropperAntiStack"))
+
+-- Setup collision groups
+AntiStack.SetupCollisionGroups()
+
+-- Setup player collisions
+game.Players.PlayerAdded:Connect(function(player)
+	player.CharacterAdded:Connect(AntiStack.SetupPlayerCollisions)
+end)
+
+for _, player in ipairs(game.Players:GetPlayers()) do
+	if player.Character then
+		AntiStack.SetupPlayerCollisions(player.Character)
+	end
+end
+
+-- Wait for dependencies
+task.wait(2)
+local PartStorage = workspace:WaitForChild("PartStorage")
+local dropPart = script.Parent:WaitForChild("Drop")
+
+local dropCount = 0
+
+while true do
+	task.wait(0.6)
+	
+	-- Debounce check
+	if not AntiStack.CanDrop(0.5) then
+		continue
+	end
+	
+	dropCount = dropCount + 1
+
+	-- Create Hello Kitty drop
+	local drop = Instance.new("Part")
+	drop.Name = "PremiumHelloKitty_" .. dropCount
+	drop.Size = Vector3.new(1.817, 1.323, 0.281)
+	drop.Material = Enum.Material.SmoothPlastic
+	drop.Color = Color3.fromRGB(151, 0, 0)
+	drop.TopSurface = Enum.SurfaceType.Smooth
+	drop.BottomSurface = Enum.SurfaceType.Smooth
+	drop.Transparency = 0
+
+	-- Add Hello Kitty mesh
+	local mesh = Instance.new("SpecialMesh")
+	mesh.MeshType = Enum.MeshType.FileMesh
+	mesh.MeshId = "rbxassetid://3071180788"
+	mesh.TextureId = ""
+	mesh.Scale = Vector3.new(1, 1, 1)
+	mesh.Parent = drop
+
+	-- Cash value
+	local cash = Instance.new("IntValue")
+	cash.Name = "Cash"
+	cash.Value = 50
+	cash.Parent = drop
+
+	-- Pink glow
+	local glow = Instance.new("PointLight")
+	glow.Brightness = 1
+	glow.Range = 8
+	glow.Color = Color3.fromRGB(255, 100, 150)
+	glow.Parent = drop
+
+	-- Minimal star particles
+	local starParticles = Instance.new("ParticleEmitter")
+	starParticles.Texture = "rbxasset://textures/particles/star.dds"
+	starParticles.Rate = 5
+	starParticles.Lifetime = NumberRange.new(1.5, 2.5)
+	starParticles.Speed = NumberRange.new(0.5)
+	starParticles.SpreadAngle = Vector2.new(90, 90)
+	starParticles.Size = NumberSequence.new{
+		NumberSequenceKeypoint.new(0, 0.25),
+		NumberSequenceKeypoint.new(1, 0.05)
+	}
+	starParticles.Color = ColorSequence.new(Color3.fromRGB(255, 150, 200))
+	starParticles.LightEmission = 0.8
+	starParticles.Parent = drop
+
+	-- Apply anti-stack physics
+	AntiStack.ApplyAntiStackPhysics(drop, dropPart)
+	
+	-- Set specific rotation
+	local spawnCFrame = drop.CFrame * CFrame.Angles(math.rad(70), math.rad(0), math.rad(180))
+	drop.CFrame = spawnCFrame
+
+	-- Rotation lock
+	local bodyPosition = Instance.new("BodyPosition")
+	bodyPosition.MaxForce = Vector3.new(0, math.huge, 0)
+	bodyPosition.Position = drop.Position
+	bodyPosition.Parent = drop
+
+	local bodyGyro = Instance.new("BodyGyro")
+	bodyGyro.MaxTorque = Vector3.new(math.huge, math.huge, math.huge)
+	bodyGyro.CFrame = spawnCFrame
+	bodyGyro.D = 500
+	bodyGyro.P = 3000
+	bodyGyro.Parent = drop
+
+	-- Parent to storage
+	drop.Parent = PartStorage
+
+	-- Spawn animation
+	TweenService:Create(mesh,
+		TweenInfo.new(0.4, Enum.EasingStyle.Back, Enum.EasingDirection.Out),
+		{Scale = Vector3.new(4, 4, 4)}
+	):Play()
+
+	-- Light flash
+	glow.Brightness = 2
+	TweenService:Create(glow,
+		TweenInfo.new(0.6, Enum.EasingStyle.Quad, Enum.EasingDirection.Out),
+		{Brightness = 1}
+	):Play()
+
+	-- Simple spawn ring
+	local spawnRing = Instance.new("Part")
+	spawnRing.Name = "SpawnEffect"
+	spawnRing.Shape = Enum.PartType.Cylinder
+	spawnRing.Size = Vector3.new(0.1, 3, 3)
+	spawnRing.Material = Enum.Material.ForceField
+	spawnRing.Color = Color3.fromRGB(255, 150, 200)
+	spawnRing.Transparency = 0.3
+	spawnRing.Anchored = true
+	spawnRing.CanCollide = false
+	spawnRing.CFrame = drop.CFrame * CFrame.Angles(0, 0, math.rad(90))
+	spawnRing.Parent = PartStorage
+
+	TweenService:Create(spawnRing,
+		TweenInfo.new(0.4, Enum.EasingStyle.Quad, Enum.EasingDirection.Out),
+		{Size = Vector3.new(0.1, 5, 5), Transparency = 1}
+	):Play()
+
+	Debris:AddItem(spawnRing, 0.5)
+
+	-- Schedule cleanup
+	AntiStack.ScheduleCleanup(drop, 180)
+end

--- a/Dropper3_NEW.lua
+++ b/Dropper3_NEW.lua
@@ -1,80 +1,93 @@
+--!strict
 --[[
-	Dropper 3 NEW - Premium Hello Kitty
-	Uses DropperCore
+	Dropper 3 NEW - Premium HelloKitty (FIXED)
 --]]
 
-local Core = require(game.ReplicatedStorage.Modules.DropperCore)
+local TweenService = game:GetService("TweenService")
+local PhysicsService = game:GetService("PhysicsService")
 
-task.wait(1)
+task.wait(2)
+local PartStorage = workspace:WaitForChild("PartStorage")
+local dropPart = script.Parent:WaitForChild("Drop")
 
--- Create template model
-local templateModel = Instance.new("Model")
-templateModel.Name = "HelloKitty3Template"
+local ORB_GROUP = "HelloKittyDrops3"
+local PLAYER_GROUP = "Players"
 
-local mainPart = Instance.new("Part")
-mainPart.Name = "PrimaryPart"
-mainPart.Size = Vector3.new(1.817, 1.323, 0.281)
-mainPart.Color = Color3.fromRGB(151, 0, 0)
-mainPart.Material = Enum.Material.SmoothPlastic
-mainPart.TopSurface = Enum.SurfaceType.Smooth
-mainPart.BottomSurface = Enum.SurfaceType.Smooth
-mainPart.Transparency = 0
-mainPart.Anchored = false
-mainPart.CanCollide = true
-mainPart.Parent = templateModel
+pcall(function()
+	PhysicsService:RegisterCollisionGroup(ORB_GROUP)
+	PhysicsService:RegisterCollisionGroup(PLAYER_GROUP)
+	PhysicsService:CollisionGroupSetCollidable(ORB_GROUP, PLAYER_GROUP, false)
+	PhysicsService:CollisionGroupSetCollidable(ORB_GROUP, ORB_GROUP, false)
+end)
 
--- Add Hello Kitty mesh
-local mesh = Instance.new("SpecialMesh")
-mesh.MeshType = Enum.MeshType.FileMesh
-mesh.MeshId = "rbxassetid://3071180788"
-mesh.TextureId = ""
-mesh.Scale = Vector3.new(4, 4, 4)
-mesh.Parent = mainPart
-
--- Add pink glow
-local light = Instance.new("PointLight")
-light.Brightness = 1
-light.Range = 10
-light.Color = Color3.fromRGB(255, 100, 150)
-light.Parent = mainPart
-
--- Set primary part
-templateModel.PrimaryPart = mainPart
-
--- Store template
-local templateStorage = game.ReplicatedStorage:FindFirstChild("DropperTemplates")
-if not templateStorage then
-	templateStorage = Instance.new("Folder")
-	templateStorage.Name = "DropperTemplates"
-	templateStorage.Parent = game.ReplicatedStorage
+local function setupPlayer(character)
+	task.wait(0.1)
+	for _, part in ipairs(character:GetDescendants()) do
+		if part:IsA("BasePart") then
+			pcall(function() part.CollisionGroup = PLAYER_GROUP end)
+		end
+	end
 end
-templateModel.Parent = templateStorage
 
--- Run dropper
-Core.RunModel({
-	model = script.Parent,
-	partStorage = workspace:WaitForChild("PartStorage"),
-	templateModel = templateModel,
+game.Players.PlayerAdded:Connect(function(player)
+	player.CharacterAdded:Connect(setupPlayer)
+end)
 
-	namePrefix = "PremiumHK_",
-	dropGroup = "HelloKittyDrops3",
-	playerGroup = "Players",
+for _, player in ipairs(game.Players:GetPlayers()) do
+	if player.Character then setupPlayer(player.Character) end
+end
 
-	dropRate = 0.6,
-	cashValue = 50,
-	lifetime = 180,
+local dropCount = 0
 
-	scaleFactor = 1.0,
-	density = 0.2,
-	friction = 0.4,
-	elasticity = 0.3,
-	
-	extraLower = 1.75,
-	fadeTime = 0.4,
-	yawDegrees = 70,
-	
-	cashOn = "primary",
-	
-	collectorNames = {"Collector", "CollectorZone", "Receiver", "Sell", "SellPad"},
-	collectorTags = {"Collector", "SellZone"},
-})
+while true do
+	task.wait(0.6)
+	dropCount = dropCount + 1
+
+	local drop = Instance.new("Part")
+	drop.Name = "PremiumHK_" .. dropCount
+	drop.Size = Vector3.new(1.817, 1.323, 0.281)
+	drop.Material = Enum.Material.SmoothPlastic
+	drop.Color = Color3.fromRGB(151, 0, 0)
+	drop.TopSurface = Enum.SurfaceType.Smooth
+	drop.BottomSurface = Enum.SurfaceType.Smooth
+	drop.Transparency = 0.7
+
+	local mesh = Instance.new("SpecialMesh")
+	mesh.MeshType = Enum.MeshType.FileMesh
+	mesh.MeshId = "rbxassetid://3071180788"
+	mesh.TextureId = ""
+	mesh.Scale = Vector3.new(1, 1, 1)
+	mesh.Parent = drop
+
+	drop.CanCollide = true
+	drop.CanTouch = true
+	drop.CanQuery = true
+	drop.CollisionGroup = ORB_GROUP
+	drop.CustomPhysicalProperties = PhysicalProperties.new(0.2, 0.4, 0.3, 1, 1)
+
+	local cash = Instance.new("IntValue")
+	cash.Name = "Cash"
+	cash.Value = 50
+	cash.Parent = drop
+
+	local glow = Instance.new("PointLight")
+	glow.Brightness = 1
+	glow.Range = 8
+	glow.Color = Color3.fromRGB(255, 100, 150)
+	glow.Parent = drop
+
+	local offsetX = math.random(-2, 2) * 0.1
+	local offsetZ = math.random(-2, 2) * 0.1
+	drop.CFrame = (dropPart.CFrame - Vector3.new(offsetX, 1.75, offsetZ)) * CFrame.Angles(math.rad(70), math.rad(0), math.rad(180))
+	drop.AssemblyLinearVelocity = Vector3.new(offsetX * 2, -10, offsetZ * 2)
+	drop:SetAttribute("SpawnTime", os.clock())
+	drop.Parent = PartStorage
+
+	TweenService:Create(drop, TweenInfo.new(0.4, Enum.EasingStyle.Quad, Enum.EasingDirection.Out), {Transparency = 0}):Play()
+	TweenService:Create(mesh, TweenInfo.new(0.4, Enum.EasingStyle.Back, Enum.EasingDirection.Out), {Scale = Vector3.new(4, 4, 4)}):Play()
+
+	glow.Brightness = 2
+	TweenService:Create(glow, TweenInfo.new(0.6, Enum.EasingStyle.Quad, Enum.EasingDirection.Out), {Brightness = 1}):Play()
+
+	task.delay(180, function() if drop and drop.Parent then drop:Destroy() end end)
+end

--- a/Dropper3_NEW.lua
+++ b/Dropper3_NEW.lua
@@ -1,145 +1,80 @@
 --[[
-	Hello Kitty Dropper 3 NEW - Premium Style Fixed
-	Optimized with anti-stack and rotation lock
+	Dropper 3 NEW - Premium Hello Kitty
+	Uses DropperCore
 --]]
 
-local TweenService = game:GetService("TweenService")
-local Debris = game:GetService("Debris")
-local AntiStack = require(workspace:WaitForChild("DropperAntiStack"))
+local Core = require(game.ReplicatedStorage.Modules.DropperCore)
 
--- Setup collision groups
-AntiStack.SetupCollisionGroups()
+task.wait(1)
 
--- Setup player collisions
-game.Players.PlayerAdded:Connect(function(player)
-	player.CharacterAdded:Connect(AntiStack.SetupPlayerCollisions)
-end)
+-- Create template model
+local templateModel = Instance.new("Model")
+templateModel.Name = "HelloKitty3Template"
 
-for _, player in ipairs(game.Players:GetPlayers()) do
-	if player.Character then
-		AntiStack.SetupPlayerCollisions(player.Character)
-	end
+local mainPart = Instance.new("Part")
+mainPart.Name = "PrimaryPart"
+mainPart.Size = Vector3.new(1.817, 1.323, 0.281)
+mainPart.Color = Color3.fromRGB(151, 0, 0)
+mainPart.Material = Enum.Material.SmoothPlastic
+mainPart.TopSurface = Enum.SurfaceType.Smooth
+mainPart.BottomSurface = Enum.SurfaceType.Smooth
+mainPart.Transparency = 0
+mainPart.Anchored = false
+mainPart.CanCollide = true
+mainPart.Parent = templateModel
+
+-- Add Hello Kitty mesh
+local mesh = Instance.new("SpecialMesh")
+mesh.MeshType = Enum.MeshType.FileMesh
+mesh.MeshId = "rbxassetid://3071180788"
+mesh.TextureId = ""
+mesh.Scale = Vector3.new(4, 4, 4)
+mesh.Parent = mainPart
+
+-- Add pink glow
+local light = Instance.new("PointLight")
+light.Brightness = 1
+light.Range = 10
+light.Color = Color3.fromRGB(255, 100, 150)
+light.Parent = mainPart
+
+-- Set primary part
+templateModel.PrimaryPart = mainPart
+
+-- Store template
+local templateStorage = game.ReplicatedStorage:FindFirstChild("DropperTemplates")
+if not templateStorage then
+	templateStorage = Instance.new("Folder")
+	templateStorage.Name = "DropperTemplates"
+	templateStorage.Parent = game.ReplicatedStorage
 end
+templateModel.Parent = templateStorage
 
--- Wait for dependencies
-task.wait(2)
-local PartStorage = workspace:WaitForChild("PartStorage")
-local dropPart = script.Parent:WaitForChild("Drop")
+-- Run dropper
+Core.RunModel({
+	model = script.Parent,
+	partStorage = workspace:WaitForChild("PartStorage"),
+	templateModel = templateModel,
 
-local dropCount = 0
+	namePrefix = "PremiumHK_",
+	dropGroup = "HelloKittyDrops3",
+	playerGroup = "Players",
 
-while true do
-	task.wait(0.6)
+	dropRate = 0.6,
+	cashValue = 50,
+	lifetime = 180,
+
+	scaleFactor = 1.0,
+	density = 0.2,
+	friction = 0.4,
+	elasticity = 0.3,
 	
-	-- Debounce check
-	if not AntiStack.CanDrop(0.5) then
-		continue
-	end
+	extraLower = 1.75,
+	fadeTime = 0.4,
+	yawDegrees = 70,
 	
-	dropCount = dropCount + 1
-
-	-- Create Hello Kitty drop
-	local drop = Instance.new("Part")
-	drop.Name = "PremiumHelloKitty_" .. dropCount
-	drop.Size = Vector3.new(1.817, 1.323, 0.281)
-	drop.Material = Enum.Material.SmoothPlastic
-	drop.Color = Color3.fromRGB(151, 0, 0)
-	drop.TopSurface = Enum.SurfaceType.Smooth
-	drop.BottomSurface = Enum.SurfaceType.Smooth
-	drop.Transparency = 0
-
-	-- Add Hello Kitty mesh
-	local mesh = Instance.new("SpecialMesh")
-	mesh.MeshType = Enum.MeshType.FileMesh
-	mesh.MeshId = "rbxassetid://3071180788"
-	mesh.TextureId = ""
-	mesh.Scale = Vector3.new(1, 1, 1)
-	mesh.Parent = drop
-
-	-- Cash value
-	local cash = Instance.new("IntValue")
-	cash.Name = "Cash"
-	cash.Value = 50
-	cash.Parent = drop
-
-	-- Pink glow
-	local glow = Instance.new("PointLight")
-	glow.Brightness = 1
-	glow.Range = 8
-	glow.Color = Color3.fromRGB(255, 100, 150)
-	glow.Parent = drop
-
-	-- Minimal star particles
-	local starParticles = Instance.new("ParticleEmitter")
-	starParticles.Texture = "rbxasset://textures/particles/star.dds"
-	starParticles.Rate = 5
-	starParticles.Lifetime = NumberRange.new(1.5, 2.5)
-	starParticles.Speed = NumberRange.new(0.5)
-	starParticles.SpreadAngle = Vector2.new(90, 90)
-	starParticles.Size = NumberSequence.new{
-		NumberSequenceKeypoint.new(0, 0.25),
-		NumberSequenceKeypoint.new(1, 0.05)
-	}
-	starParticles.Color = ColorSequence.new(Color3.fromRGB(255, 150, 200))
-	starParticles.LightEmission = 0.8
-	starParticles.Parent = drop
-
-	-- Apply anti-stack physics
-	AntiStack.ApplyAntiStackPhysics(drop, dropPart)
+	cashOn = "primary",
 	
-	-- Set specific rotation
-	local spawnCFrame = drop.CFrame * CFrame.Angles(math.rad(70), math.rad(0), math.rad(180))
-	drop.CFrame = spawnCFrame
-
-	-- Rotation lock
-	local bodyPosition = Instance.new("BodyPosition")
-	bodyPosition.MaxForce = Vector3.new(0, math.huge, 0)
-	bodyPosition.Position = drop.Position
-	bodyPosition.Parent = drop
-
-	local bodyGyro = Instance.new("BodyGyro")
-	bodyGyro.MaxTorque = Vector3.new(math.huge, math.huge, math.huge)
-	bodyGyro.CFrame = spawnCFrame
-	bodyGyro.D = 500
-	bodyGyro.P = 3000
-	bodyGyro.Parent = drop
-
-	-- Parent to storage
-	drop.Parent = PartStorage
-
-	-- Spawn animation
-	TweenService:Create(mesh,
-		TweenInfo.new(0.4, Enum.EasingStyle.Back, Enum.EasingDirection.Out),
-		{Scale = Vector3.new(4, 4, 4)}
-	):Play()
-
-	-- Light flash
-	glow.Brightness = 2
-	TweenService:Create(glow,
-		TweenInfo.new(0.6, Enum.EasingStyle.Quad, Enum.EasingDirection.Out),
-		{Brightness = 1}
-	):Play()
-
-	-- Simple spawn ring
-	local spawnRing = Instance.new("Part")
-	spawnRing.Name = "SpawnEffect"
-	spawnRing.Shape = Enum.PartType.Cylinder
-	spawnRing.Size = Vector3.new(0.1, 3, 3)
-	spawnRing.Material = Enum.Material.ForceField
-	spawnRing.Color = Color3.fromRGB(255, 150, 200)
-	spawnRing.Transparency = 0.3
-	spawnRing.Anchored = true
-	spawnRing.CanCollide = false
-	spawnRing.CFrame = drop.CFrame * CFrame.Angles(0, 0, math.rad(90))
-	spawnRing.Parent = PartStorage
-
-	TweenService:Create(spawnRing,
-		TweenInfo.new(0.4, Enum.EasingStyle.Quad, Enum.EasingDirection.Out),
-		{Size = Vector3.new(0.1, 5, 5), Transparency = 1}
-	):Play()
-
-	Debris:AddItem(spawnRing, 0.5)
-
-	-- Schedule cleanup
-	AntiStack.ScheduleCleanup(drop, 180)
-end
+	collectorNames = {"Collector", "CollectorZone", "Receiver", "Sell", "SellPad"},
+	collectorTags = {"Collector", "SellZone"},
+})

--- a/Dropper4_NEW.lua
+++ b/Dropper4_NEW.lua
@@ -1,0 +1,127 @@
+--[[
+	Cinnamoroll Dropper 4 NEW - White Heart Style Fixed
+	Optimized with anti-stack
+--]]
+
+local TweenService = game:GetService("TweenService")
+local Debris = game:GetService("Debris")
+local AntiStack = require(workspace:WaitForChild("DropperAntiStack"))
+
+-- Setup collision groups
+AntiStack.SetupCollisionGroups()
+
+-- Setup player collisions
+game.Players.PlayerAdded:Connect(function(player)
+	player.CharacterAdded:Connect(AntiStack.SetupPlayerCollisions)
+end)
+
+for _, player in ipairs(game.Players:GetPlayers()) do
+	if player.Character then
+		AntiStack.SetupPlayerCollisions(player.Character)
+	end
+end
+
+-- Wait for dependencies
+task.wait(2)
+local PartStorage = workspace:WaitForChild("PartStorage")
+local dropPart = script.Parent:WaitForChild("Drop")
+
+local cakeCount = 0
+
+while true do
+	task.wait(0.9)
+	
+	-- Debounce check
+	if not AntiStack.CanDrop(0.8) then
+		continue
+	end
+	
+	cakeCount = cakeCount + 1
+
+	-- Create white heart
+	local cake = Instance.new("Part")
+	cake.Name = "WhiteHeart_" .. cakeCount
+	cake.Size = Vector3.new(2, 2, 2)
+	cake.Material = Enum.Material.SmoothPlastic
+	cake.BrickColor = BrickColor.new("Institutional white")
+	cake.TopSurface = Enum.SurfaceType.Smooth
+	cake.BottomSurface = Enum.SurfaceType.Smooth
+	cake.Reflectance = 0.2
+
+	-- Add heart mesh
+	local mesh = Instance.new("SpecialMesh")
+	mesh.MeshType = Enum.MeshType.FileMesh
+	mesh.MeshId = "rbxassetid://601198887"
+	mesh.TextureId = ""
+	mesh.Scale = Vector3.new(0.001, 0.001, 0.001)
+	mesh.Parent = cake
+
+	-- Cash value
+	local cash = Instance.new("IntValue")
+	cash.Name = "Cash"
+	cash.Value = 40
+	cash.Parent = cake
+
+	-- Sweet glow
+	local glow = Instance.new("PointLight")
+	glow.Brightness = 0.6
+	glow.Range = 6
+	glow.Color = Color3.fromRGB(255, 204, 204)
+	glow.Parent = cake
+
+	-- Minimal particles
+	local berries = Instance.new("ParticleEmitter")
+	berries.Texture = "rbxasset://textures/particles/sparkles_main.dds"
+	berries.Rate = 4
+	berries.Lifetime = NumberRange.new(1, 1.5)
+	berries.Speed = NumberRange.new(0.5)
+	berries.SpreadAngle = Vector2.new(20, 20)
+	berries.Color = ColorSequence.new(Color3.fromRGB(255, 99, 71))
+	berries.Size = NumberSequence.new{
+		NumberSequenceKeypoint.new(0, 0.2),
+		NumberSequenceKeypoint.new(1, 0.05)
+	}
+	berries.LightEmission = 0.4
+	berries.Parent = cake
+
+	-- Apply anti-stack physics
+	AntiStack.ApplyAntiStackPhysics(cake, dropPart)
+
+	-- Parent to storage
+	cake.Parent = PartStorage
+
+	-- Spawn animation
+	TweenService:Create(mesh,
+		TweenInfo.new(0.4, Enum.EasingStyle.Back, Enum.EasingDirection.Out),
+		{Scale = Vector3.new(0.04, 0.04, 0.04)}
+	):Play()
+
+	-- Light flash
+	glow.Brightness = 1.2
+	TweenService:Create(glow,
+		TweenInfo.new(0.5, Enum.EasingStyle.Quad, Enum.EasingDirection.Out),
+		{Brightness = 0.6}
+	):Play()
+
+	-- Simple puff effect
+	local puff = Instance.new("ParticleEmitter")
+	puff.Texture = "rbxassetid://262979222"
+	puff.Rate = 0
+	puff.Speed = NumberRange.new(0)
+	puff.Lifetime = NumberRange.new(0.3)
+	puff.Size = NumberSequence.new({
+		NumberSequenceKeypoint.new(0, 0.1),
+		NumberSequenceKeypoint.new(1, 1.5)
+	})
+	puff.Transparency = NumberSequence.new({
+		NumberSequenceKeypoint.new(0, 0.3),
+		NumberSequenceKeypoint.new(1, 1)
+	})
+	puff.Color = ColorSequence.new(Color3.fromRGB(255, 182, 193))
+	puff.Parent = cake
+	puff:Emit(1)
+	Debris:AddItem(puff, 1)
+
+	-- Schedule cleanup
+	AntiStack.ScheduleCleanup(cake, 180)
+end

--- a/Dropper4_NEW.lua
+++ b/Dropper4_NEW.lua
@@ -1,127 +1,80 @@
 --[[
-	Cinnamoroll Dropper 4 NEW - White Heart Style Fixed
-	Optimized with anti-stack
+	Dropper 4 NEW - White Heart Style
+	Uses DropperCore
 --]]
 
-local TweenService = game:GetService("TweenService")
-local Debris = game:GetService("Debris")
-local AntiStack = require(workspace:WaitForChild("DropperAntiStack"))
+local Core = require(game.ReplicatedStorage.Modules.DropperCore)
 
--- Setup collision groups
-AntiStack.SetupCollisionGroups()
+task.wait(1)
 
--- Setup player collisions
-game.Players.PlayerAdded:Connect(function(player)
-	player.CharacterAdded:Connect(AntiStack.SetupPlayerCollisions)
-end)
+-- Create template model
+local templateModel = Instance.new("Model")
+templateModel.Name = "WhiteHeartTemplate"
 
-for _, player in ipairs(game.Players:GetPlayers()) do
-	if player.Character then
-		AntiStack.SetupPlayerCollisions(player.Character)
-	end
+local mainPart = Instance.new("Part")
+mainPart.Name = "PrimaryPart"
+mainPart.Size = Vector3.new(2, 2, 2)
+mainPart.BrickColor = BrickColor.new("Institutional white")
+mainPart.Material = Enum.Material.SmoothPlastic
+mainPart.TopSurface = Enum.SurfaceType.Smooth
+mainPart.BottomSurface = Enum.SurfaceType.Smooth
+mainPart.Reflectance = 0.2
+mainPart.Transparency = 0
+mainPart.Anchored = false
+mainPart.CanCollide = true
+mainPart.Parent = templateModel
+
+-- Add heart mesh
+local mesh = Instance.new("SpecialMesh")
+mesh.MeshType = Enum.MeshType.FileMesh
+mesh.MeshId = "rbxassetid://601198887"
+mesh.TextureId = ""
+mesh.Scale = Vector3.new(0.04, 0.04, 0.04)
+mesh.Parent = mainPart
+
+-- Add sweet glow
+local light = Instance.new("PointLight")
+light.Brightness = 0.6
+light.Range = 7
+light.Color = Color3.fromRGB(255, 204, 204)
+light.Parent = mainPart
+
+-- Set primary part
+templateModel.PrimaryPart = mainPart
+
+-- Store template
+local templateStorage = game.ReplicatedStorage:FindFirstChild("DropperTemplates")
+if not templateStorage then
+	templateStorage = Instance.new("Folder")
+	templateStorage.Name = "DropperTemplates"
+	templateStorage.Parent = game.ReplicatedStorage
 end
+templateModel.Parent = templateStorage
 
--- Wait for dependencies
-task.wait(2)
-local PartStorage = workspace:WaitForChild("PartStorage")
-local dropPart = script.Parent:WaitForChild("Drop")
+-- Run dropper
+Core.RunModel({
+	model = script.Parent,
+	partStorage = workspace:WaitForChild("PartStorage"),
+	templateModel = templateModel,
 
-local cakeCount = 0
+	namePrefix = "WhiteHeart_",
+	dropGroup = "HelloKittyDrops4",
+	playerGroup = "Players",
 
-while true do
-	task.wait(0.9)
+	dropRate = 0.9,
+	cashValue = 40,
+	lifetime = 180,
+
+	scaleFactor = 1.0,
+	density = 0.4,
+	friction = 0.6,
+	elasticity = 0.1,
 	
-	-- Debounce check
-	if not AntiStack.CanDrop(0.8) then
-		continue
-	end
+	extraLower = 1.75,
+	fadeTime = 0.4,
 	
-	cakeCount = cakeCount + 1
-
-	-- Create white heart
-	local cake = Instance.new("Part")
-	cake.Name = "WhiteHeart_" .. cakeCount
-	cake.Size = Vector3.new(2, 2, 2)
-	cake.Material = Enum.Material.SmoothPlastic
-	cake.BrickColor = BrickColor.new("Institutional white")
-	cake.TopSurface = Enum.SurfaceType.Smooth
-	cake.BottomSurface = Enum.SurfaceType.Smooth
-	cake.Reflectance = 0.2
-
-	-- Add heart mesh
-	local mesh = Instance.new("SpecialMesh")
-	mesh.MeshType = Enum.MeshType.FileMesh
-	mesh.MeshId = "rbxassetid://601198887"
-	mesh.TextureId = ""
-	mesh.Scale = Vector3.new(0.001, 0.001, 0.001)
-	mesh.Parent = cake
-
-	-- Cash value
-	local cash = Instance.new("IntValue")
-	cash.Name = "Cash"
-	cash.Value = 40
-	cash.Parent = cake
-
-	-- Sweet glow
-	local glow = Instance.new("PointLight")
-	glow.Brightness = 0.6
-	glow.Range = 6
-	glow.Color = Color3.fromRGB(255, 204, 204)
-	glow.Parent = cake
-
-	-- Minimal particles
-	local berries = Instance.new("ParticleEmitter")
-	berries.Texture = "rbxasset://textures/particles/sparkles_main.dds"
-	berries.Rate = 4
-	berries.Lifetime = NumberRange.new(1, 1.5)
-	berries.Speed = NumberRange.new(0.5)
-	berries.SpreadAngle = Vector2.new(20, 20)
-	berries.Color = ColorSequence.new(Color3.fromRGB(255, 99, 71))
-	berries.Size = NumberSequence.new{
-		NumberSequenceKeypoint.new(0, 0.2),
-		NumberSequenceKeypoint.new(1, 0.05)
-	}
-	berries.LightEmission = 0.4
-	berries.Parent = cake
-
-	-- Apply anti-stack physics
-	AntiStack.ApplyAntiStackPhysics(cake, dropPart)
-
-	-- Parent to storage
-	cake.Parent = PartStorage
-
-	-- Spawn animation
-	TweenService:Create(mesh,
-		TweenInfo.new(0.4, Enum.EasingStyle.Back, Enum.EasingDirection.Out),
-		{Scale = Vector3.new(0.04, 0.04, 0.04)}
-	):Play()
-
-	-- Light flash
-	glow.Brightness = 1.2
-	TweenService:Create(glow,
-		TweenInfo.new(0.5, Enum.EasingStyle.Quad, Enum.EasingDirection.Out),
-		{Brightness = 0.6}
-	):Play()
-
-	-- Simple puff effect
-	local puff = Instance.new("ParticleEmitter")
-	puff.Texture = "rbxassetid://262979222"
-	puff.Rate = 0
-	puff.Speed = NumberRange.new(0)
-	puff.Lifetime = NumberRange.new(0.3)
-	puff.Size = NumberSequence.new({
-		NumberSequenceKeypoint.new(0, 0.1),
-		NumberSequenceKeypoint.new(1, 1.5)
-	})
-	puff.Transparency = NumberSequence.new({
-		NumberSequenceKeypoint.new(0, 0.3),
-		NumberSequenceKeypoint.new(1, 1)
-	})
-	puff.Color = ColorSequence.new(Color3.fromRGB(255, 182, 193))
-	puff.Parent = cake
-	puff:Emit(1)
-	Debris:AddItem(puff, 1)
-
-	-- Schedule cleanup
-	AntiStack.ScheduleCleanup(cake, 180)
-end
+	cashOn = "primary",
+	
+	collectorNames = {"Collector", "CollectorZone", "Receiver", "Sell", "SellPad"},
+	collectorTags = {"Collector", "SellZone"},
+})

--- a/Dropper4_NEW.lua
+++ b/Dropper4_NEW.lua
@@ -1,80 +1,91 @@
+--!strict
 --[[
-	Dropper 4 NEW - White Heart Style
-	Uses DropperCore
+	Dropper 4 NEW - White Heart (FIXED)
 --]]
 
-local Core = require(game.ReplicatedStorage.Modules.DropperCore)
+local TweenService = game:GetService("TweenService")
+local PhysicsService = game:GetService("PhysicsService")
 
-task.wait(1)
+task.wait(2)
+local PartStorage = workspace:WaitForChild("PartStorage")
+local dropPart = script.Parent:WaitForChild("Drop")
 
--- Create template model
-local templateModel = Instance.new("Model")
-templateModel.Name = "WhiteHeartTemplate"
+local ORB_GROUP = "HelloKittyDrops4"
+local PLAYER_GROUP = "Players"
 
-local mainPart = Instance.new("Part")
-mainPart.Name = "PrimaryPart"
-mainPart.Size = Vector3.new(2, 2, 2)
-mainPart.BrickColor = BrickColor.new("Institutional white")
-mainPart.Material = Enum.Material.SmoothPlastic
-mainPart.TopSurface = Enum.SurfaceType.Smooth
-mainPart.BottomSurface = Enum.SurfaceType.Smooth
-mainPart.Reflectance = 0.2
-mainPart.Transparency = 0
-mainPart.Anchored = false
-mainPart.CanCollide = true
-mainPart.Parent = templateModel
+pcall(function()
+	PhysicsService:RegisterCollisionGroup(ORB_GROUP)
+	PhysicsService:RegisterCollisionGroup(PLAYER_GROUP)
+	PhysicsService:CollisionGroupSetCollidable(ORB_GROUP, PLAYER_GROUP, false)
+	PhysicsService:CollisionGroupSetCollidable(ORB_GROUP, ORB_GROUP, false)
+end)
 
--- Add heart mesh
-local mesh = Instance.new("SpecialMesh")
-mesh.MeshType = Enum.MeshType.FileMesh
-mesh.MeshId = "rbxassetid://601198887"
-mesh.TextureId = ""
-mesh.Scale = Vector3.new(0.04, 0.04, 0.04)
-mesh.Parent = mainPart
-
--- Add sweet glow
-local light = Instance.new("PointLight")
-light.Brightness = 0.6
-light.Range = 7
-light.Color = Color3.fromRGB(255, 204, 204)
-light.Parent = mainPart
-
--- Set primary part
-templateModel.PrimaryPart = mainPart
-
--- Store template
-local templateStorage = game.ReplicatedStorage:FindFirstChild("DropperTemplates")
-if not templateStorage then
-	templateStorage = Instance.new("Folder")
-	templateStorage.Name = "DropperTemplates"
-	templateStorage.Parent = game.ReplicatedStorage
+local function setupPlayer(character)
+	task.wait(0.1)
+	for _, part in ipairs(character:GetDescendants()) do
+		if part:IsA("BasePart") then
+			pcall(function() part.CollisionGroup = PLAYER_GROUP end)
+		end
+	end
 end
-templateModel.Parent = templateStorage
 
--- Run dropper
-Core.RunModel({
-	model = script.Parent,
-	partStorage = workspace:WaitForChild("PartStorage"),
-	templateModel = templateModel,
+game.Players.PlayerAdded:Connect(function(player)
+	player.CharacterAdded:Connect(setupPlayer)
+end)
 
-	namePrefix = "WhiteHeart_",
-	dropGroup = "HelloKittyDrops4",
-	playerGroup = "Players",
+for _, player in ipairs(game.Players:GetPlayers()) do
+	if player.Character then setupPlayer(player.Character) end
+end
 
-	dropRate = 0.9,
-	cashValue = 40,
-	lifetime = 180,
+local dropCount = 0
 
-	scaleFactor = 1.0,
-	density = 0.4,
-	friction = 0.6,
-	elasticity = 0.1,
-	
-	extraLower = 1.75,
-	fadeTime = 0.4,
-	
-	cashOn = "primary",
-	
-	collectorNames = {"Collector", "CollectorZone", "Receiver", "Sell", "SellPad"},
-	collectorTags = {"Collector", "SellZone"},
-})
+while true do
+	task.wait(0.9)
+	dropCount = dropCount + 1
+
+	local cake = Instance.new("Part")
+	cake.Name = "WhiteHeart_" .. dropCount
+	cake.Size = Vector3.new(2, 2, 2)
+	cake.Material = Enum.Material.SmoothPlastic
+	cake.BrickColor = BrickColor.new("Institutional white")
+	cake.TopSurface = Enum.SurfaceType.Smooth
+	cake.BottomSurface = Enum.SurfaceType.Smooth
+	cake.Reflectance = 0.2
+	cake.Transparency = 0.7
+
+	local mesh = Instance.new("SpecialMesh")
+	mesh.MeshType = Enum.MeshType.FileMesh
+	mesh.MeshId = "rbxassetid://601198887"
+	mesh.TextureId = ""
+	mesh.Scale = Vector3.new(0.001, 0.001, 0.001)
+	mesh.Parent = cake
+
+	cake.CanCollide = true
+	cake.CanTouch = true
+	cake.CanQuery = true
+	cake.CollisionGroup = ORB_GROUP
+	cake.CustomPhysicalProperties = PhysicalProperties.new(0.4, 0.6, 0.1, 1, 1)
+
+	local cash = Instance.new("IntValue")
+	cash.Name = "Cash"
+	cash.Value = 40
+	cash.Parent = cake
+
+	local glow = Instance.new("PointLight")
+	glow.Brightness = 0.6
+	glow.Range = 6
+	glow.Color = Color3.fromRGB(255, 204, 204)
+	glow.Parent = cake
+
+	local offsetX = math.random(-2, 2) * 0.1
+	local offsetZ = math.random(-2, 2) * 0.1
+	cake.CFrame = (dropPart.CFrame - Vector3.new(offsetX, 1.75, offsetZ))
+	cake.AssemblyLinearVelocity = Vector3.new(offsetX * 2, -10, offsetZ * 2)
+	cake:SetAttribute("SpawnTime", os.clock())
+	cake.Parent = PartStorage
+
+	TweenService:Create(cake, TweenInfo.new(0.4, Enum.EasingStyle.Quad, Enum.EasingDirection.Out), {Transparency = 0}):Play()
+	TweenService:Create(mesh, TweenInfo.new(0.4, Enum.EasingStyle.Back, Enum.EasingDirection.Out), {Scale = Vector3.new(0.04, 0.04, 0.04)}):Play()
+
+	task.delay(180, function() if cake and cake.Parent then cake:Destroy() end end)
+end

--- a/Dropper5_NEW.lua
+++ b/Dropper5_NEW.lua
@@ -1,0 +1,131 @@
+--[[
+	Dropper 5 NEW - Ice Cream Style Fixed
+	Optimized with anti-stack and proper scaling
+--]]
+
+local TweenService = game:GetService("TweenService")
+local Debris = game:GetService("Debris")
+local AntiStack = require(workspace:WaitForChild("DropperAntiStack"))
+
+-- Setup collision groups
+AntiStack.SetupCollisionGroups()
+
+-- Setup player collisions
+game.Players.PlayerAdded:Connect(function(player)
+	player.CharacterAdded:Connect(AntiStack.SetupPlayerCollisions)
+end)
+
+for _, player in ipairs(game.Players:GetPlayers()) do
+	if player.Character then
+		AntiStack.SetupPlayerCollisions(player.Character)
+	end
+end
+
+-- Wait for dependencies
+task.wait(2)
+local PartStorage = workspace:WaitForChild("PartStorage")
+local dropPart = script.Parent:WaitForChild("Drop")
+
+-- Ice cream settings
+local MESH_ID = "rbxassetid://1486490132"
+local TEXTURE_ID = "rbxassetid://1486490402"
+local BASE_SCALE = Vector3.new(1.177, 2.512, 1.164)
+local SCALE_OVERALL = 1.8
+local THICKEN = Vector3.new(1.8, 1.0, 1.8)
+local FINAL_SCALE = Vector3.new(
+	BASE_SCALE.X * THICKEN.X * SCALE_OVERALL,
+	BASE_SCALE.Y * THICKEN.Y * SCALE_OVERALL,
+	BASE_SCALE.Z * THICKEN.Z * SCALE_OVERALL
+)
+
+local count = 0
+
+while true do
+	task.wait(1.5)
+	
+	-- Debounce check
+	if not AntiStack.CanDrop(1.4) then
+		continue
+	end
+	
+	count = count + 1
+
+	-- Create ice cream
+	local orb = Instance.new("Part")
+	orb.Name = "IceCream_" .. count
+	orb.Size = Vector3.new(2, 2, 2)
+	orb.Material = Enum.Material.SmoothPlastic
+	orb.TopSurface = Enum.SurfaceType.Smooth
+	orb.BottomSurface = Enum.SurfaceType.Smooth
+	orb.Color = Color3.new(1, 1, 1)
+	orb.Transparency = 0.7
+
+	-- Add mesh
+	local mesh = Instance.new("SpecialMesh")
+	mesh.MeshType = Enum.MeshType.FileMesh
+	mesh.MeshId = MESH_ID
+	mesh.TextureId = TEXTURE_ID
+	mesh.Scale = FINAL_SCALE * 0.5
+	mesh.Parent = orb
+
+	-- Cash value
+	local cash = Instance.new("IntValue")
+	cash.Name = "Cash"
+	cash.Value = 12
+	cash.Parent = orb
+
+	-- Simple light
+	local light = Instance.new("PointLight")
+	light.Brightness = 0.4
+	light.Range = 5
+	light.Color = Color3.new(1, 1, 1)
+	light.Parent = orb
+
+	-- Apply anti-stack physics
+	AntiStack.ApplyAntiStackPhysics(orb, dropPart)
+	
+	orb.CFrame = orb.CFrame * CFrame.Angles(math.rad(180), math.rad(180), 0)
+
+	-- Parent to storage
+	orb.Parent = PartStorage
+
+	-- Smooth animations
+	TweenService:Create(orb,
+		TweenInfo.new(0.5, Enum.EasingStyle.Quad, Enum.EasingDirection.Out),
+		{Transparency = 0}
+	):Play()
+
+	TweenService:Create(mesh,
+		TweenInfo.new(0.5, Enum.EasingStyle.Back, Enum.EasingDirection.Out),
+		{Scale = FINAL_SCALE}
+	):Play()
+
+	-- Light flash
+	light.Brightness = 1.2
+	TweenService:Create(light,
+		TweenInfo.new(0.5, Enum.EasingStyle.Quad, Enum.EasingDirection.Out),
+		{Brightness = 0.4}
+	):Play()
+
+	-- Simple spawn effect
+	local ring = Instance.new("ParticleEmitter")
+	ring.Texture = "rbxassetid://262979222"
+	ring.Rate = 0
+	ring.Speed = NumberRange.new(0)
+	ring.Lifetime = NumberRange.new(0.3)
+	ring.Size = NumberSequence.new({
+		NumberSequenceKeypoint.new(0, 0.1),
+		NumberSequenceKeypoint.new(1, 2)
+	})
+	ring.Transparency = NumberSequence.new({
+		NumberSequenceKeypoint.new(0, 0.3),
+		NumberSequenceKeypoint.new(1, 1)
+	})
+	ring.Color = ColorSequence.new(Color3.new(1, 1, 1))
+	ring.Parent = orb
+	ring:Emit(1)
+	Debris:AddItem(ring, 1)
+
+	-- Schedule cleanup
+	AntiStack.ScheduleCleanup(orb, 180)
+end

--- a/Dropper5_NEW.lua
+++ b/Dropper5_NEW.lua
@@ -1,34 +1,13 @@
 --[[
-	Dropper 5 NEW - Ice Cream Style Fixed
-	Optimized with anti-stack and proper scaling
+	Dropper 5 NEW - Ice Cream Style
+	Uses DropperCore
 --]]
 
-local TweenService = game:GetService("TweenService")
-local Debris = game:GetService("Debris")
-local AntiStack = require(workspace:WaitForChild("DropperAntiStack"))
+local Core = require(game.ReplicatedStorage.Modules.DropperCore)
 
--- Setup collision groups
-AntiStack.SetupCollisionGroups()
+task.wait(1)
 
--- Setup player collisions
-game.Players.PlayerAdded:Connect(function(player)
-	player.CharacterAdded:Connect(AntiStack.SetupPlayerCollisions)
-end)
-
-for _, player in ipairs(game.Players:GetPlayers()) do
-	if player.Character then
-		AntiStack.SetupPlayerCollisions(player.Character)
-	end
-end
-
--- Wait for dependencies
-task.wait(2)
-local PartStorage = workspace:WaitForChild("PartStorage")
-local dropPart = script.Parent:WaitForChild("Drop")
-
--- Ice cream settings
-local MESH_ID = "rbxassetid://1486490132"
-local TEXTURE_ID = "rbxassetid://1486490402"
+-- Scale calculations
 local BASE_SCALE = Vector3.new(1.177, 2.512, 1.164)
 local SCALE_OVERALL = 1.8
 local THICKEN = Vector3.new(1.8, 1.0, 1.8)
@@ -38,94 +17,74 @@ local FINAL_SCALE = Vector3.new(
 	BASE_SCALE.Z * THICKEN.Z * SCALE_OVERALL
 )
 
-local count = 0
+-- Create template model
+local templateModel = Instance.new("Model")
+templateModel.Name = "IceCreamTemplate"
 
-while true do
-	task.wait(1.5)
-	
-	-- Debounce check
-	if not AntiStack.CanDrop(1.4) then
-		continue
-	end
-	
-	count = count + 1
+local mainPart = Instance.new("Part")
+mainPart.Name = "PrimaryPart"
+mainPart.Size = Vector3.new(2, 2, 2)
+mainPart.Color = Color3.new(1, 1, 1)
+mainPart.Material = Enum.Material.SmoothPlastic
+mainPart.TopSurface = Enum.SurfaceType.Smooth
+mainPart.BottomSurface = Enum.SurfaceType.Smooth
+mainPart.Transparency = 0
+mainPart.Anchored = false
+mainPart.CanCollide = true
+mainPart.Parent = templateModel
 
-	-- Create ice cream
-	local orb = Instance.new("Part")
-	orb.Name = "IceCream_" .. count
-	orb.Size = Vector3.new(2, 2, 2)
-	orb.Material = Enum.Material.SmoothPlastic
-	orb.TopSurface = Enum.SurfaceType.Smooth
-	orb.BottomSurface = Enum.SurfaceType.Smooth
-	orb.Color = Color3.new(1, 1, 1)
-	orb.Transparency = 0.7
+-- Add ice cream mesh
+local mesh = Instance.new("SpecialMesh")
+mesh.MeshType = Enum.MeshType.FileMesh
+mesh.MeshId = "rbxassetid://1486490132"
+mesh.TextureId = "rbxassetid://1486490402"
+mesh.Scale = FINAL_SCALE
+mesh.Parent = mainPart
 
-	-- Add mesh
-	local mesh = Instance.new("SpecialMesh")
-	mesh.MeshType = Enum.MeshType.FileMesh
-	mesh.MeshId = MESH_ID
-	mesh.TextureId = TEXTURE_ID
-	mesh.Scale = FINAL_SCALE * 0.5
-	mesh.Parent = orb
+-- Add light
+local light = Instance.new("PointLight")
+light.Brightness = 0.4
+light.Range = 6
+light.Color = Color3.new(1, 1, 1)
+light.Parent = mainPart
 
-	-- Cash value
-	local cash = Instance.new("IntValue")
-	cash.Name = "Cash"
-	cash.Value = 12
-	cash.Parent = orb
+-- Set primary part
+templateModel.PrimaryPart = mainPart
 
-	-- Simple light
-	local light = Instance.new("PointLight")
-	light.Brightness = 0.4
-	light.Range = 5
-	light.Color = Color3.new(1, 1, 1)
-	light.Parent = orb
-
-	-- Apply anti-stack physics
-	AntiStack.ApplyAntiStackPhysics(orb, dropPart)
-	
-	orb.CFrame = orb.CFrame * CFrame.Angles(math.rad(180), math.rad(180), 0)
-
-	-- Parent to storage
-	orb.Parent = PartStorage
-
-	-- Smooth animations
-	TweenService:Create(orb,
-		TweenInfo.new(0.5, Enum.EasingStyle.Quad, Enum.EasingDirection.Out),
-		{Transparency = 0}
-	):Play()
-
-	TweenService:Create(mesh,
-		TweenInfo.new(0.5, Enum.EasingStyle.Back, Enum.EasingDirection.Out),
-		{Scale = FINAL_SCALE}
-	):Play()
-
-	-- Light flash
-	light.Brightness = 1.2
-	TweenService:Create(light,
-		TweenInfo.new(0.5, Enum.EasingStyle.Quad, Enum.EasingDirection.Out),
-		{Brightness = 0.4}
-	):Play()
-
-	-- Simple spawn effect
-	local ring = Instance.new("ParticleEmitter")
-	ring.Texture = "rbxassetid://262979222"
-	ring.Rate = 0
-	ring.Speed = NumberRange.new(0)
-	ring.Lifetime = NumberRange.new(0.3)
-	ring.Size = NumberSequence.new({
-		NumberSequenceKeypoint.new(0, 0.1),
-		NumberSequenceKeypoint.new(1, 2)
-	})
-	ring.Transparency = NumberSequence.new({
-		NumberSequenceKeypoint.new(0, 0.3),
-		NumberSequenceKeypoint.new(1, 1)
-	})
-	ring.Color = ColorSequence.new(Color3.new(1, 1, 1))
-	ring.Parent = orb
-	ring:Emit(1)
-	Debris:AddItem(ring, 1)
-
-	-- Schedule cleanup
-	AntiStack.ScheduleCleanup(orb, 180)
+-- Store template
+local templateStorage = game.ReplicatedStorage:FindFirstChild("DropperTemplates")
+if not templateStorage then
+	templateStorage = Instance.new("Folder")
+	templateStorage.Name = "DropperTemplates"
+	templateStorage.Parent = game.ReplicatedStorage
 end
+templateModel.Parent = templateStorage
+
+-- Run dropper
+Core.RunModel({
+	model = script.Parent,
+	partStorage = workspace:WaitForChild("PartStorage"),
+	templateModel = templateModel,
+
+	namePrefix = "IceCream_",
+	dropGroup = "HelloKittyDrops5",
+	playerGroup = "Players",
+
+	dropRate = 1.5,
+	cashValue = 12,
+	lifetime = 180,
+
+	scaleFactor = 1.0,
+	density = 0.3,
+	friction = 0.5,
+	elasticity = 0.1,
+	
+	extraLower = 2.0,
+	fadeTime = 0.5,
+	yawDegrees = 180,
+	
+	cashOn = "primary",
+	
+	collectorNames = {"Collector", "CollectorZone", "Receiver", "Sell", "SellPad"},
+	collectorTags = {"Collector", "SellZone"},
+})

--- a/Dropper5_NEW.lua
+++ b/Dropper5_NEW.lua
@@ -1,13 +1,42 @@
+--!strict
 --[[
-	Dropper 5 NEW - Ice Cream Style
-	Uses DropperCore
+	Dropper 5 NEW - Ice Cream (FIXED)
 --]]
 
-local Core = require(game.ReplicatedStorage.Modules.DropperCore)
+local TweenService = game:GetService("TweenService")
+local PhysicsService = game:GetService("PhysicsService")
 
-task.wait(1)
+task.wait(2)
+local PartStorage = workspace:WaitForChild("PartStorage")
+local dropPart = script.Parent:WaitForChild("Drop")
 
--- Scale calculations
+local ORB_GROUP = "HelloKittyDrops5"
+local PLAYER_GROUP = "Players"
+
+pcall(function()
+	PhysicsService:RegisterCollisionGroup(ORB_GROUP)
+	PhysicsService:RegisterCollisionGroup(PLAYER_GROUP)
+	PhysicsService:CollisionGroupSetCollidable(ORB_GROUP, PLAYER_GROUP, false)
+	PhysicsService:CollisionGroupSetCollidable(ORB_GROUP, ORB_GROUP, false)
+end)
+
+local function setupPlayer(character)
+	task.wait(0.1)
+	for _, part in ipairs(character:GetDescendants()) do
+		if part:IsA("BasePart") then
+			pcall(function() part.CollisionGroup = PLAYER_GROUP end)
+		end
+	end
+end
+
+game.Players.PlayerAdded:Connect(function(player)
+	player.CharacterAdded:Connect(setupPlayer)
+end)
+
+for _, player in ipairs(game.Players:GetPlayers()) do
+	if player.Character then setupPlayer(player.Character) end
+end
+
 local BASE_SCALE = Vector3.new(1.177, 2.512, 1.164)
 local SCALE_OVERALL = 1.8
 local THICKEN = Vector3.new(1.8, 1.0, 1.8)
@@ -17,74 +46,54 @@ local FINAL_SCALE = Vector3.new(
 	BASE_SCALE.Z * THICKEN.Z * SCALE_OVERALL
 )
 
--- Create template model
-local templateModel = Instance.new("Model")
-templateModel.Name = "IceCreamTemplate"
+local dropCount = 0
 
-local mainPart = Instance.new("Part")
-mainPart.Name = "PrimaryPart"
-mainPart.Size = Vector3.new(2, 2, 2)
-mainPart.Color = Color3.new(1, 1, 1)
-mainPart.Material = Enum.Material.SmoothPlastic
-mainPart.TopSurface = Enum.SurfaceType.Smooth
-mainPart.BottomSurface = Enum.SurfaceType.Smooth
-mainPart.Transparency = 0
-mainPart.Anchored = false
-mainPart.CanCollide = true
-mainPart.Parent = templateModel
+while true do
+	task.wait(1.5)
+	dropCount = dropCount + 1
 
--- Add ice cream mesh
-local mesh = Instance.new("SpecialMesh")
-mesh.MeshType = Enum.MeshType.FileMesh
-mesh.MeshId = "rbxassetid://1486490132"
-mesh.TextureId = "rbxassetid://1486490402"
-mesh.Scale = FINAL_SCALE
-mesh.Parent = mainPart
+	local orb = Instance.new("Part")
+	orb.Name = "IceCream_" .. dropCount
+	orb.Size = Vector3.new(2, 2, 2)
+	orb.Material = Enum.Material.SmoothPlastic
+	orb.TopSurface = Enum.SurfaceType.Smooth
+	orb.BottomSurface = Enum.SurfaceType.Smooth
+	orb.Color = Color3.new(1, 1, 1)
+	orb.Transparency = 0.7
 
--- Add light
-local light = Instance.new("PointLight")
-light.Brightness = 0.4
-light.Range = 6
-light.Color = Color3.new(1, 1, 1)
-light.Parent = mainPart
+	local mesh = Instance.new("SpecialMesh")
+	mesh.MeshType = Enum.MeshType.FileMesh
+	mesh.MeshId = "rbxassetid://1486490132"
+	mesh.TextureId = "rbxassetid://1486490402"
+	mesh.Scale = FINAL_SCALE * 0.5
+	mesh.Parent = orb
 
--- Set primary part
-templateModel.PrimaryPart = mainPart
+	orb.CanCollide = true
+	orb.CanTouch = true
+	orb.CanQuery = true
+	orb.CollisionGroup = ORB_GROUP
+	orb.CustomPhysicalProperties = PhysicalProperties.new(0.3, 0.5, 0.1, 1, 1)
 
--- Store template
-local templateStorage = game.ReplicatedStorage:FindFirstChild("DropperTemplates")
-if not templateStorage then
-	templateStorage = Instance.new("Folder")
-	templateStorage.Name = "DropperTemplates"
-	templateStorage.Parent = game.ReplicatedStorage
+	local cash = Instance.new("IntValue")
+	cash.Name = "Cash"
+	cash.Value = 12
+	cash.Parent = orb
+
+	local light = Instance.new("PointLight")
+	light.Brightness = 0.4
+	light.Range = 5
+	light.Color = Color3.new(1, 1, 1)
+	light.Parent = orb
+
+	local offsetX = math.random(-2, 2) * 0.1
+	local offsetZ = math.random(-2, 2) * 0.1
+	orb.CFrame = (dropPart.CFrame - Vector3.new(offsetX, 2, offsetZ)) * CFrame.Angles(math.rad(180), math.rad(180), 0)
+	orb.AssemblyLinearVelocity = Vector3.new(offsetX * 2, -10, offsetZ * 2)
+	orb:SetAttribute("SpawnTime", os.clock())
+	orb.Parent = PartStorage
+
+	TweenService:Create(orb, TweenInfo.new(0.5, Enum.EasingStyle.Quad, Enum.EasingDirection.Out), {Transparency = 0}):Play()
+	TweenService:Create(mesh, TweenInfo.new(0.5, Enum.EasingStyle.Back, Enum.EasingDirection.Out), {Scale = FINAL_SCALE}):Play()
+
+	task.delay(180, function() if orb and orb.Parent then orb:Destroy() end end)
 end
-templateModel.Parent = templateStorage
-
--- Run dropper
-Core.RunModel({
-	model = script.Parent,
-	partStorage = workspace:WaitForChild("PartStorage"),
-	templateModel = templateModel,
-
-	namePrefix = "IceCream_",
-	dropGroup = "HelloKittyDrops5",
-	playerGroup = "Players",
-
-	dropRate = 1.5,
-	cashValue = 12,
-	lifetime = 180,
-
-	scaleFactor = 1.0,
-	density = 0.3,
-	friction = 0.5,
-	elasticity = 0.1,
-	
-	extraLower = 2.0,
-	fadeTime = 0.5,
-	yawDegrees = 180,
-	
-	cashOn = "primary",
-	
-	collectorNames = {"Collector", "CollectorZone", "Receiver", "Sell", "SellPad"},
-	collectorTags = {"Collector", "SellZone"},
-})

--- a/Dropper6_NEW.lua
+++ b/Dropper6_NEW.lua
@@ -1,0 +1,75 @@
+--[[
+	Dropper 6 NEW - Mesh Dropper Fixed
+	Optimized with anti-stack
+--]]
+
+local AntiStack = require(workspace:WaitForChild("DropperAntiStack"))
+
+-- Setup collision groups
+AntiStack.SetupCollisionGroups()
+
+-- Setup player collisions
+game.Players.PlayerAdded:Connect(function(player)
+	player.CharacterAdded:Connect(AntiStack.SetupPlayerCollisions)
+end)
+
+for _, player in ipairs(game.Players:GetPlayers()) do
+	if player.Character then
+		AntiStack.SetupPlayerCollisions(player.Character)
+	end
+end
+
+-- Wait for dependencies
+task.wait(2)
+local PartStorage = workspace:WaitForChild("PartStorage")
+local dropPart = script.Parent:WaitForChild("Drop")
+
+-- Mesh settings
+local meshDrop = true
+local meshID = "http://www.roblox.com/asset?id=160003363"
+local textureID = "http://www.roblox.com/asset/?id=192068356"
+
+local dropCount = 0
+
+while true do
+	task.wait(1.5)
+	
+	-- Debounce check
+	if not AntiStack.CanDrop(1.4) then
+		continue
+	end
+	
+	dropCount = dropCount + 1
+
+	-- Create part
+	local part = Instance.new("Part")
+	part.Name = "MeshDrop_" .. dropCount
+	part.FormFactor = "Custom"
+	part.Size = Vector3.new(1, 5, 4)
+	part.TopSurface = "Smooth"
+	part.BottomSurface = "Smooth"
+	part.Material = Enum.Material.SmoothPlastic
+
+	-- Add mesh
+	if meshDrop then
+		local m = Instance.new("SpecialMesh")
+		m.MeshId = meshID
+		m.TextureId = textureID
+		m.Parent = part
+	end
+
+	-- Cash value
+	local cash = Instance.new("IntValue")
+	cash.Name = "Cash"
+	cash.Value = 12
+	cash.Parent = part
+
+	-- Apply anti-stack physics
+	AntiStack.ApplyAntiStackPhysics(part, dropPart)
+
+	-- Parent to storage
+	part.Parent = PartStorage
+
+	-- Schedule cleanup
+	AntiStack.ScheduleCleanup(part, 20)
+end

--- a/Dropper6_NEW.lua
+++ b/Dropper6_NEW.lua
@@ -1,71 +1,77 @@
+--!strict
 --[[
-	Dropper 6 NEW - Custom Mesh Style
-	Uses DropperCore
+	Dropper 6 NEW - Custom Mesh (FIXED)
 --]]
 
-local Core = require(game.ReplicatedStorage.Modules.DropperCore)
+local PhysicsService = game:GetService("PhysicsService")
 
-task.wait(1)
+task.wait(2)
+local PartStorage = workspace:WaitForChild("PartStorage")
+local dropPart = script.Parent:WaitForChild("Drop")
 
--- Create template model
-local templateModel = Instance.new("Model")
-templateModel.Name = "Dropper6Template"
+local ORB_GROUP = "HelloKittyDrops6"
+local PLAYER_GROUP = "Players"
 
-local mainPart = Instance.new("Part")
-mainPart.Name = "PrimaryPart"
-mainPart.Size = Vector3.new(1, 5, 4)
-mainPart.Material = Enum.Material.SmoothPlastic
-mainPart.TopSurface = Enum.SurfaceType.Smooth
-mainPart.BottomSurface = Enum.SurfaceType.Smooth
-mainPart.Transparency = 0
-mainPart.Anchored = false
-mainPart.CanCollide = true
-mainPart.Parent = templateModel
+pcall(function()
+	PhysicsService:RegisterCollisionGroup(ORB_GROUP)
+	PhysicsService:RegisterCollisionGroup(PLAYER_GROUP)
+	PhysicsService:CollisionGroupSetCollidable(ORB_GROUP, PLAYER_GROUP, false)
+	PhysicsService:CollisionGroupSetCollidable(ORB_GROUP, ORB_GROUP, false)
+end)
 
--- Add mesh
-local mesh = Instance.new("SpecialMesh")
-mesh.MeshType = Enum.MeshType.FileMesh
-mesh.MeshId = "http://www.roblox.com/asset?id=160003363"
-mesh.TextureId = "http://www.roblox.com/asset/?id=192068356"
-mesh.Scale = Vector3.new(1, 1, 1)
-mesh.Parent = mainPart
-
--- Set primary part
-templateModel.PrimaryPart = mainPart
-
--- Store template
-local templateStorage = game.ReplicatedStorage:FindFirstChild("DropperTemplates")
-if not templateStorage then
-	templateStorage = Instance.new("Folder")
-	templateStorage.Name = "DropperTemplates"
-	templateStorage.Parent = game.ReplicatedStorage
+local function setupPlayer(character)
+	task.wait(0.1)
+	for _, part in ipairs(character:GetDescendants()) do
+		if part:IsA("BasePart") then
+			pcall(function() part.CollisionGroup = PLAYER_GROUP end)
+		end
+	end
 end
-templateModel.Parent = templateStorage
 
--- Run dropper
-Core.RunModel({
-	model = script.Parent,
-	partStorage = workspace:WaitForChild("PartStorage"),
-	templateModel = templateModel,
+game.Players.PlayerAdded:Connect(function(player)
+	player.CharacterAdded:Connect(setupPlayer)
+end)
 
-	namePrefix = "Drop6_",
-	dropGroup = "HelloKittyDrops6",
-	playerGroup = "Players",
+for _, player in ipairs(game.Players:GetPlayers()) do
+	if player.Character then setupPlayer(player.Character) end
+end
 
-	dropRate = 1.5,
-	cashValue = 12,
-	lifetime = 20,
+local dropCount = 0
 
-	scaleFactor = 1.0,
-	density = 0.3,
-	friction = 0.4,
-	elasticity = 0.1,
-	
-	extraLower = 5.0,
-	fadeTime = 0.4,
-	
-	cashOn = "primary",
-	
-	collectorNames = {"Collector", "CollectorZone", "Receiver", "Sell", "SellPad"},
-	collectorTags = {"Collector", "SellZone"},
-})
+while true do
+	task.wait(1.5)
+	dropCount = dropCount + 1
+
+	local part = Instance.new("Part")
+	part.Name = "MeshDrop_" .. dropCount
+	part.FormFactor = "Custom"
+	part.Size = Vector3.new(1, 5, 4)
+	part.TopSurface = "Smooth"
+	part.BottomSurface = "Smooth"
+	part.Material = Enum.Material.SmoothPlastic
+
+	local m = Instance.new("SpecialMesh")
+	m.MeshId = "http://www.roblox.com/asset?id=160003363"
+	m.TextureId = "http://www.roblox.com/asset/?id=192068356"
+	m.Parent = part
+
+	part.CanCollide = true
+	part.CanTouch = true
+	part.CanQuery = true
+	part.CollisionGroup = ORB_GROUP
+	part.CustomPhysicalProperties = PhysicalProperties.new(0.3, 0.4, 0.1, 1, 1)
+
+	local cash = Instance.new("IntValue")
+	cash.Name = "Cash"
+	cash.Value = 12
+	cash.Parent = part
+
+	local offsetX = math.random(-2, 2) * 0.1
+	local offsetZ = math.random(-2, 2) * 0.1
+	part.CFrame = (dropPart.CFrame - Vector3.new(offsetX, 5, offsetZ))
+	part.AssemblyLinearVelocity = Vector3.new(offsetX * 2, -10, offsetZ * 2)
+	part:SetAttribute("SpawnTime", os.clock())
+	part.Parent = PartStorage
+
+	task.delay(20, function() if part and part.Parent then part:Destroy() end end)
+end

--- a/Dropper6_NEW.lua
+++ b/Dropper6_NEW.lua
@@ -1,75 +1,71 @@
 --[[
-	Dropper 6 NEW - Mesh Dropper Fixed
-	Optimized with anti-stack
+	Dropper 6 NEW - Custom Mesh Style
+	Uses DropperCore
 --]]
 
-local AntiStack = require(workspace:WaitForChild("DropperAntiStack"))
+local Core = require(game.ReplicatedStorage.Modules.DropperCore)
 
--- Setup collision groups
-AntiStack.SetupCollisionGroups()
+task.wait(1)
 
--- Setup player collisions
-game.Players.PlayerAdded:Connect(function(player)
-	player.CharacterAdded:Connect(AntiStack.SetupPlayerCollisions)
-end)
+-- Create template model
+local templateModel = Instance.new("Model")
+templateModel.Name = "Dropper6Template"
 
-for _, player in ipairs(game.Players:GetPlayers()) do
-	if player.Character then
-		AntiStack.SetupPlayerCollisions(player.Character)
-	end
+local mainPart = Instance.new("Part")
+mainPart.Name = "PrimaryPart"
+mainPart.Size = Vector3.new(1, 5, 4)
+mainPart.Material = Enum.Material.SmoothPlastic
+mainPart.TopSurface = Enum.SurfaceType.Smooth
+mainPart.BottomSurface = Enum.SurfaceType.Smooth
+mainPart.Transparency = 0
+mainPart.Anchored = false
+mainPart.CanCollide = true
+mainPart.Parent = templateModel
+
+-- Add mesh
+local mesh = Instance.new("SpecialMesh")
+mesh.MeshType = Enum.MeshType.FileMesh
+mesh.MeshId = "http://www.roblox.com/asset?id=160003363"
+mesh.TextureId = "http://www.roblox.com/asset/?id=192068356"
+mesh.Scale = Vector3.new(1, 1, 1)
+mesh.Parent = mainPart
+
+-- Set primary part
+templateModel.PrimaryPart = mainPart
+
+-- Store template
+local templateStorage = game.ReplicatedStorage:FindFirstChild("DropperTemplates")
+if not templateStorage then
+	templateStorage = Instance.new("Folder")
+	templateStorage.Name = "DropperTemplates"
+	templateStorage.Parent = game.ReplicatedStorage
 end
+templateModel.Parent = templateStorage
 
--- Wait for dependencies
-task.wait(2)
-local PartStorage = workspace:WaitForChild("PartStorage")
-local dropPart = script.Parent:WaitForChild("Drop")
+-- Run dropper
+Core.RunModel({
+	model = script.Parent,
+	partStorage = workspace:WaitForChild("PartStorage"),
+	templateModel = templateModel,
 
--- Mesh settings
-local meshDrop = true
-local meshID = "http://www.roblox.com/asset?id=160003363"
-local textureID = "http://www.roblox.com/asset/?id=192068356"
+	namePrefix = "Drop6_",
+	dropGroup = "HelloKittyDrops6",
+	playerGroup = "Players",
 
-local dropCount = 0
+	dropRate = 1.5,
+	cashValue = 12,
+	lifetime = 20,
 
-while true do
-	task.wait(1.5)
+	scaleFactor = 1.0,
+	density = 0.3,
+	friction = 0.4,
+	elasticity = 0.1,
 	
-	-- Debounce check
-	if not AntiStack.CanDrop(1.4) then
-		continue
-	end
+	extraLower = 5.0,
+	fadeTime = 0.4,
 	
-	dropCount = dropCount + 1
-
-	-- Create part
-	local part = Instance.new("Part")
-	part.Name = "MeshDrop_" .. dropCount
-	part.FormFactor = "Custom"
-	part.Size = Vector3.new(1, 5, 4)
-	part.TopSurface = "Smooth"
-	part.BottomSurface = "Smooth"
-	part.Material = Enum.Material.SmoothPlastic
-
-	-- Add mesh
-	if meshDrop then
-		local m = Instance.new("SpecialMesh")
-		m.MeshId = meshID
-		m.TextureId = textureID
-		m.Parent = part
-	end
-
-	-- Cash value
-	local cash = Instance.new("IntValue")
-	cash.Name = "Cash"
-	cash.Value = 12
-	cash.Parent = part
-
-	-- Apply anti-stack physics
-	AntiStack.ApplyAntiStackPhysics(part, dropPart)
-
-	-- Parent to storage
-	part.Parent = PartStorage
-
-	-- Schedule cleanup
-	AntiStack.ScheduleCleanup(part, 20)
-end
+	cashOn = "primary",
+	
+	collectorNames = {"Collector", "CollectorZone", "Receiver", "Sell", "SellPad"},
+	collectorTags = {"Collector", "SellZone"},
+})

--- a/Dropper7_NEW.lua
+++ b/Dropper7_NEW.lua
@@ -1,63 +1,64 @@
 --[[
 	Dropper 7 NEW - Transition Dropper
-	Between basic and advanced droppers
+	Uses DropperCore
 --]]
 
-local AntiStack = require(workspace:WaitForChild("DropperAntiStack"))
+local Core = require(game.ReplicatedStorage.Modules.DropperCore)
 
--- Setup collision groups
-AntiStack.SetupCollisionGroups()
+task.wait(1)
 
--- Setup player collisions
-game.Players.PlayerAdded:Connect(function(player)
-	player.CharacterAdded:Connect(AntiStack.SetupPlayerCollisions)
-end)
+-- Create template model
+local templateModel = Instance.new("Model")
+templateModel.Name = "Dropper7Template"
 
-for _, player in ipairs(game.Players:GetPlayers()) do
-	if player.Character then
-		AntiStack.SetupPlayerCollisions(player.Character)
-	end
+local mainPart = Instance.new("Part")
+mainPart.Name = "PrimaryPart"
+mainPart.Size = Vector3.new(1.2, 1.2, 1.2)
+mainPart.BrickColor = BrickColor.new("Hot pink")
+mainPart.Material = Enum.Material.SmoothPlastic
+mainPart.TopSurface = Enum.SurfaceType.Smooth
+mainPart.BottomSurface = Enum.SurfaceType.Smooth
+mainPart.Transparency = 0
+mainPart.Anchored = false
+mainPart.CanCollide = true
+mainPart.Parent = templateModel
+
+-- Set primary part
+templateModel.PrimaryPart = mainPart
+
+-- Store template
+local templateStorage = game.ReplicatedStorage:FindFirstChild("DropperTemplates")
+if not templateStorage then
+	templateStorage = Instance.new("Folder")
+	templateStorage.Name = "DropperTemplates"
+	templateStorage.Parent = game.ReplicatedStorage
 end
+templateModel.Parent = templateStorage
 
--- Wait for dependencies
-task.wait(2)
-local PartStorage = workspace:WaitForChild("PartStorage")
-local dropPart = script.Parent:WaitForChild("Drop")
+-- Run dropper
+Core.RunModel({
+	model = script.Parent,
+	partStorage = workspace:WaitForChild("PartStorage"),
+	templateModel = templateModel,
 
-local dropCount = 0
+	namePrefix = "Transition7_",
+	dropGroup = "HelloKittyDrops7",
+	playerGroup = "Players",
 
-while true do
-	task.wait(1.2)
+	dropRate = 1.2,
+	cashValue = 80,
+	lifetime = 150,
+
+	scaleFactor = 1.0,
+	density = 0.3,
+	friction = 0.4,
+	elasticity = 0.1,
 	
-	-- Debounce check
-	if not AntiStack.CanDrop(1.1) then
-		continue
-	end
+	extraLower = 1.5,
+	fadeTime = 0.4,
 	
-	dropCount = dropCount + 1
-
-	-- Create part
-	local part = Instance.new("Part")
-	part.Name = "TransitionDrop7_" .. dropCount
-	part.BrickColor = BrickColor.new("Hot pink")
-	part.Material = "SmoothPlastic"
-	part.FormFactor = "Custom"
-	part.Size = Vector3.new(1.2, 1.2, 1.2)
-	part.TopSurface = "Smooth"
-	part.BottomSurface = "Smooth"
-
-	-- Cash value
-	local cash = Instance.new("IntValue")
-	cash.Name = "Cash"
-	cash.Value = 80
-	cash.Parent = part
-
-	-- Apply anti-stack physics
-	AntiStack.ApplyAntiStackPhysics(part, dropPart)
-
-	-- Parent to storage
-	part.Parent = PartStorage
-
-	-- Cleanup
-	AntiStack.ScheduleCleanup(part, 150)
-end
+	cashOn = "primary",
+	
+	collectorNames = {"Collector", "CollectorZone", "Receiver", "Sell", "SellPad"},
+	collectorTags = {"Collector", "SellZone"},
+})

--- a/Dropper7_NEW.lua
+++ b/Dropper7_NEW.lua
@@ -1,64 +1,72 @@
+--!strict
 --[[
-	Dropper 7 NEW - Transition Dropper
-	Uses DropperCore
+	Dropper 7 NEW - Hot Pink Transition (FIXED)
 --]]
 
-local Core = require(game.ReplicatedStorage.Modules.DropperCore)
+local PhysicsService = game:GetService("PhysicsService")
 
-task.wait(1)
+task.wait(2)
+local PartStorage = workspace:WaitForChild("PartStorage")
+local dropPart = script.Parent:WaitForChild("Drop")
 
--- Create template model
-local templateModel = Instance.new("Model")
-templateModel.Name = "Dropper7Template"
+local ORB_GROUP = "HelloKittyDrops7"
+local PLAYER_GROUP = "Players"
 
-local mainPart = Instance.new("Part")
-mainPart.Name = "PrimaryPart"
-mainPart.Size = Vector3.new(1.2, 1.2, 1.2)
-mainPart.BrickColor = BrickColor.new("Hot pink")
-mainPart.Material = Enum.Material.SmoothPlastic
-mainPart.TopSurface = Enum.SurfaceType.Smooth
-mainPart.BottomSurface = Enum.SurfaceType.Smooth
-mainPart.Transparency = 0
-mainPart.Anchored = false
-mainPart.CanCollide = true
-mainPart.Parent = templateModel
+pcall(function()
+	PhysicsService:RegisterCollisionGroup(ORB_GROUP)
+	PhysicsService:RegisterCollisionGroup(PLAYER_GROUP)
+	PhysicsService:CollisionGroupSetCollidable(ORB_GROUP, PLAYER_GROUP, false)
+	PhysicsService:CollisionGroupSetCollidable(ORB_GROUP, ORB_GROUP, false)
+end)
 
--- Set primary part
-templateModel.PrimaryPart = mainPart
-
--- Store template
-local templateStorage = game.ReplicatedStorage:FindFirstChild("DropperTemplates")
-if not templateStorage then
-	templateStorage = Instance.new("Folder")
-	templateStorage.Name = "DropperTemplates"
-	templateStorage.Parent = game.ReplicatedStorage
+local function setupPlayer(character)
+	task.wait(0.1)
+	for _, part in ipairs(character:GetDescendants()) do
+		if part:IsA("BasePart") then
+			pcall(function() part.CollisionGroup = PLAYER_GROUP end)
+		end
+	end
 end
-templateModel.Parent = templateStorage
 
--- Run dropper
-Core.RunModel({
-	model = script.Parent,
-	partStorage = workspace:WaitForChild("PartStorage"),
-	templateModel = templateModel,
+game.Players.PlayerAdded:Connect(function(player)
+	player.CharacterAdded:Connect(setupPlayer)
+end)
 
-	namePrefix = "Transition7_",
-	dropGroup = "HelloKittyDrops7",
-	playerGroup = "Players",
+for _, player in ipairs(game.Players:GetPlayers()) do
+	if player.Character then setupPlayer(player.Character) end
+end
 
-	dropRate = 1.2,
-	cashValue = 80,
-	lifetime = 150,
+local dropCount = 0
 
-	scaleFactor = 1.0,
-	density = 0.3,
-	friction = 0.4,
-	elasticity = 0.1,
-	
-	extraLower = 1.5,
-	fadeTime = 0.4,
-	
-	cashOn = "primary",
-	
-	collectorNames = {"Collector", "CollectorZone", "Receiver", "Sell", "SellPad"},
-	collectorTags = {"Collector", "SellZone"},
-})
+while true do
+	task.wait(1.2)
+	dropCount = dropCount + 1
+
+	local part = Instance.new("Part")
+	part.Name = "Transition7_" .. dropCount
+	part.Size = Vector3.new(1.2, 1.2, 1.2)
+	part.BrickColor = BrickColor.new("Hot pink")
+	part.Material = Enum.Material.SmoothPlastic
+	part.TopSurface = Enum.SurfaceType.Smooth
+	part.BottomSurface = Enum.SurfaceType.Smooth
+
+	part.CanCollide = true
+	part.CanTouch = true
+	part.CanQuery = true
+	part.CollisionGroup = ORB_GROUP
+	part.CustomPhysicalProperties = PhysicalProperties.new(0.3, 0.4, 0.1, 1, 1)
+
+	local cash = Instance.new("IntValue")
+	cash.Name = "Cash"
+	cash.Value = 80
+	cash.Parent = part
+
+	local offsetX = math.random(-2, 2) * 0.1
+	local offsetZ = math.random(-2, 2) * 0.1
+	part.CFrame = (dropPart.CFrame - Vector3.new(offsetX, 1.5, offsetZ))
+	part.AssemblyLinearVelocity = Vector3.new(offsetX * 2, -10, offsetZ * 2)
+	part:SetAttribute("SpawnTime", os.clock())
+	part.Parent = PartStorage
+
+	task.delay(150, function() if part and part.Parent then part:Destroy() end end)
+end

--- a/Dropper7_NEW.lua
+++ b/Dropper7_NEW.lua
@@ -1,0 +1,63 @@
+--[[
+	Dropper 7 NEW - Transition Dropper
+	Between basic and advanced droppers
+--]]
+
+local AntiStack = require(workspace:WaitForChild("DropperAntiStack"))
+
+-- Setup collision groups
+AntiStack.SetupCollisionGroups()
+
+-- Setup player collisions
+game.Players.PlayerAdded:Connect(function(player)
+	player.CharacterAdded:Connect(AntiStack.SetupPlayerCollisions)
+end)
+
+for _, player in ipairs(game.Players:GetPlayers()) do
+	if player.Character then
+		AntiStack.SetupPlayerCollisions(player.Character)
+	end
+end
+
+-- Wait for dependencies
+task.wait(2)
+local PartStorage = workspace:WaitForChild("PartStorage")
+local dropPart = script.Parent:WaitForChild("Drop")
+
+local dropCount = 0
+
+while true do
+	task.wait(1.2)
+	
+	-- Debounce check
+	if not AntiStack.CanDrop(1.1) then
+		continue
+	end
+	
+	dropCount = dropCount + 1
+
+	-- Create part
+	local part = Instance.new("Part")
+	part.Name = "TransitionDrop7_" .. dropCount
+	part.BrickColor = BrickColor.new("Hot pink")
+	part.Material = "SmoothPlastic"
+	part.FormFactor = "Custom"
+	part.Size = Vector3.new(1.2, 1.2, 1.2)
+	part.TopSurface = "Smooth"
+	part.BottomSurface = "Smooth"
+
+	-- Cash value
+	local cash = Instance.new("IntValue")
+	cash.Name = "Cash"
+	cash.Value = 80
+	cash.Parent = part
+
+	-- Apply anti-stack physics
+	AntiStack.ApplyAntiStackPhysics(part, dropPart)
+
+	-- Parent to storage
+	part.Parent = PartStorage
+
+	-- Cleanup
+	AntiStack.ScheduleCleanup(part, 150)
+end

--- a/Dropper8_10_Fixed.lua
+++ b/Dropper8_10_Fixed.lua
@@ -50,7 +50,7 @@ while true do
 	-- Cash value
 	local cash = Instance.new("IntValue")
 	cash.Name = "Cash"
-	cash.Value = 100
+	cash.Value = 150
 	cash.Parent = part
 
 	-- Apply anti-stack physics

--- a/Dropper8_NEW.lua
+++ b/Dropper8_NEW.lua
@@ -1,0 +1,63 @@
+--[[
+	Dropper 8 NEW - Lime Green Fabric
+	Optimized with anti-stack
+--]]
+
+local AntiStack = require(workspace:WaitForChild("DropperAntiStack"))
+
+-- Setup collision groups
+AntiStack.SetupCollisionGroups()
+
+-- Setup player collisions
+game.Players.PlayerAdded:Connect(function(player)
+	player.CharacterAdded:Connect(AntiStack.SetupPlayerCollisions)
+end)
+
+for _, player in ipairs(game.Players:GetPlayers()) do
+	if player.Character then
+		AntiStack.SetupPlayerCollisions(player.Character)
+	end
+end
+
+-- Wait for dependencies
+task.wait(2)
+local PartStorage = workspace:WaitForChild("PartStorage")
+local dropPart = script.Parent:WaitForChild("Drop")
+
+local dropCount = 0
+
+while true do
+	task.wait(0.6)
+	
+	-- Debounce check to prevent spam
+	if not AntiStack.CanDrop(0.55) then
+		continue
+	end
+	
+	dropCount = dropCount + 1
+
+	-- Create part
+	local part = Instance.new("Part")
+	part.Name = "FabricDrop8_" .. dropCount
+	part.BrickColor = BrickColor.new("Lime green")
+	part.Material = "Fabric"
+	part.FormFactor = "Custom"
+	part.Size = Vector3.new(1, 1, 1)
+	part.TopSurface = "Smooth"
+	part.BottomSurface = "Smooth"
+
+	-- Cash value
+	local cash = Instance.new("IntValue")
+	cash.Name = "Cash"
+	cash.Value = 120
+	cash.Parent = part
+
+	-- Apply anti-stack physics
+	AntiStack.ApplyAntiStackPhysics(part, dropPart)
+
+	-- Parent to storage
+	part.Parent = PartStorage
+
+	-- Long lifetime
+	AntiStack.ScheduleCleanup(part, 2000)
+end

--- a/Dropper8_NEW.lua
+++ b/Dropper8_NEW.lua
@@ -1,63 +1,64 @@
 --[[
-	Dropper 8 NEW - Lime Green Fabric
-	Optimized with anti-stack
+	Dropper 8 NEW - Lime Green
+	Uses DropperCore
 --]]
 
-local AntiStack = require(workspace:WaitForChild("DropperAntiStack"))
+local Core = require(game.ReplicatedStorage.Modules.DropperCore)
 
--- Setup collision groups
-AntiStack.SetupCollisionGroups()
+task.wait(1)
 
--- Setup player collisions
-game.Players.PlayerAdded:Connect(function(player)
-	player.CharacterAdded:Connect(AntiStack.SetupPlayerCollisions)
-end)
+-- Create template model
+local templateModel = Instance.new("Model")
+templateModel.Name = "Dropper8Template"
 
-for _, player in ipairs(game.Players:GetPlayers()) do
-	if player.Character then
-		AntiStack.SetupPlayerCollisions(player.Character)
-	end
+local mainPart = Instance.new("Part")
+mainPart.Name = "PrimaryPart"
+mainPart.Size = Vector3.new(1, 1, 1)
+mainPart.BrickColor = BrickColor.new("Lime green")
+mainPart.Material = Enum.Material.Fabric
+mainPart.TopSurface = Enum.SurfaceType.Smooth
+mainPart.BottomSurface = Enum.SurfaceType.Smooth
+mainPart.Transparency = 0
+mainPart.Anchored = false
+mainPart.CanCollide = true
+mainPart.Parent = templateModel
+
+-- Set primary part
+templateModel.PrimaryPart = mainPart
+
+-- Store template
+local templateStorage = game.ReplicatedStorage:FindFirstChild("DropperTemplates")
+if not templateStorage then
+	templateStorage = Instance.new("Folder")
+	templateStorage.Name = "DropperTemplates"
+	templateStorage.Parent = game.ReplicatedStorage
 end
+templateModel.Parent = templateStorage
 
--- Wait for dependencies
-task.wait(2)
-local PartStorage = workspace:WaitForChild("PartStorage")
-local dropPart = script.Parent:WaitForChild("Drop")
+-- Run dropper
+Core.RunModel({
+	model = script.Parent,
+	partStorage = workspace:WaitForChild("PartStorage"),
+	templateModel = templateModel,
 
-local dropCount = 0
+	namePrefix = "Fabric8_",
+	dropGroup = "HelloKittyDrops8",
+	playerGroup = "Players",
 
-while true do
-	task.wait(0.6)
+	dropRate = 0.6,
+	cashValue = 120,
+	lifetime = 2000,
+
+	scaleFactor = 1.0,
+	density = 0.3,
+	friction = 0.4,
+	elasticity = 0.1,
 	
-	-- Debounce check to prevent spam
-	if not AntiStack.CanDrop(0.55) then
-		continue
-	end
+	extraLower = 1.5,
+	fadeTime = 0.4,
 	
-	dropCount = dropCount + 1
-
-	-- Create part
-	local part = Instance.new("Part")
-	part.Name = "FabricDrop8_" .. dropCount
-	part.BrickColor = BrickColor.new("Lime green")
-	part.Material = "Fabric"
-	part.FormFactor = "Custom"
-	part.Size = Vector3.new(1, 1, 1)
-	part.TopSurface = "Smooth"
-	part.BottomSurface = "Smooth"
-
-	-- Cash value
-	local cash = Instance.new("IntValue")
-	cash.Name = "Cash"
-	cash.Value = 120
-	cash.Parent = part
-
-	-- Apply anti-stack physics
-	AntiStack.ApplyAntiStackPhysics(part, dropPart)
-
-	-- Parent to storage
-	part.Parent = PartStorage
-
-	-- Long lifetime
-	AntiStack.ScheduleCleanup(part, 2000)
-end
+	cashOn = "primary",
+	
+	collectorNames = {"Collector", "CollectorZone", "Receiver", "Sell", "SellPad"},
+	collectorTags = {"Collector", "SellZone"},
+})

--- a/Dropper8_NEW.lua
+++ b/Dropper8_NEW.lua
@@ -1,64 +1,72 @@
+--!strict
 --[[
-	Dropper 8 NEW - Lime Green
-	Uses DropperCore
+	Dropper 8 NEW - Lime Green Fabric (FIXED)
 --]]
 
-local Core = require(game.ReplicatedStorage.Modules.DropperCore)
+local PhysicsService = game:GetService("PhysicsService")
 
-task.wait(1)
+task.wait(2)
+local PartStorage = workspace:WaitForChild("PartStorage")
+local dropPart = script.Parent:WaitForChild("Drop")
 
--- Create template model
-local templateModel = Instance.new("Model")
-templateModel.Name = "Dropper8Template"
+local ORB_GROUP = "HelloKittyDrops8"
+local PLAYER_GROUP = "Players"
 
-local mainPart = Instance.new("Part")
-mainPart.Name = "PrimaryPart"
-mainPart.Size = Vector3.new(1, 1, 1)
-mainPart.BrickColor = BrickColor.new("Lime green")
-mainPart.Material = Enum.Material.Fabric
-mainPart.TopSurface = Enum.SurfaceType.Smooth
-mainPart.BottomSurface = Enum.SurfaceType.Smooth
-mainPart.Transparency = 0
-mainPart.Anchored = false
-mainPart.CanCollide = true
-mainPart.Parent = templateModel
+pcall(function()
+	PhysicsService:RegisterCollisionGroup(ORB_GROUP)
+	PhysicsService:RegisterCollisionGroup(PLAYER_GROUP)
+	PhysicsService:CollisionGroupSetCollidable(ORB_GROUP, PLAYER_GROUP, false)
+	PhysicsService:CollisionGroupSetCollidable(ORB_GROUP, ORB_GROUP, false)
+end)
 
--- Set primary part
-templateModel.PrimaryPart = mainPart
-
--- Store template
-local templateStorage = game.ReplicatedStorage:FindFirstChild("DropperTemplates")
-if not templateStorage then
-	templateStorage = Instance.new("Folder")
-	templateStorage.Name = "DropperTemplates"
-	templateStorage.Parent = game.ReplicatedStorage
+local function setupPlayer(character)
+	task.wait(0.1)
+	for _, part in ipairs(character:GetDescendants()) do
+		if part:IsA("BasePart") then
+			pcall(function() part.CollisionGroup = PLAYER_GROUP end)
+		end
+	end
 end
-templateModel.Parent = templateStorage
 
--- Run dropper
-Core.RunModel({
-	model = script.Parent,
-	partStorage = workspace:WaitForChild("PartStorage"),
-	templateModel = templateModel,
+game.Players.PlayerAdded:Connect(function(player)
+	player.CharacterAdded:Connect(setupPlayer)
+end)
 
-	namePrefix = "Fabric8_",
-	dropGroup = "HelloKittyDrops8",
-	playerGroup = "Players",
+for _, player in ipairs(game.Players:GetPlayers()) do
+	if player.Character then setupPlayer(player.Character) end
+end
 
-	dropRate = 0.6,
-	cashValue = 120,
-	lifetime = 2000,
+local dropCount = 0
 
-	scaleFactor = 1.0,
-	density = 0.3,
-	friction = 0.4,
-	elasticity = 0.1,
-	
-	extraLower = 1.5,
-	fadeTime = 0.4,
-	
-	cashOn = "primary",
-	
-	collectorNames = {"Collector", "CollectorZone", "Receiver", "Sell", "SellPad"},
-	collectorTags = {"Collector", "SellZone"},
-})
+while true do
+	task.wait(0.6)
+	dropCount = dropCount + 1
+
+	local part = Instance.new("Part")
+	part.Name = "Fabric8_" .. dropCount
+	part.Size = Vector3.new(1, 1, 1)
+	part.BrickColor = BrickColor.new("Lime green")
+	part.Material = Enum.Material.Fabric
+	part.TopSurface = Enum.SurfaceType.Smooth
+	part.BottomSurface = Enum.SurfaceType.Smooth
+
+	part.CanCollide = true
+	part.CanTouch = true
+	part.CanQuery = true
+	part.CollisionGroup = ORB_GROUP
+	part.CustomPhysicalProperties = PhysicalProperties.new(0.3, 0.4, 0.1, 1, 1)
+
+	local cash = Instance.new("IntValue")
+	cash.Name = "Cash"
+	cash.Value = 120
+	cash.Parent = part
+
+	local offsetX = math.random(-2, 2) * 0.1
+	local offsetZ = math.random(-2, 2) * 0.1
+	part.CFrame = (dropPart.CFrame - Vector3.new(offsetX, 1.5, offsetZ))
+	part.AssemblyLinearVelocity = Vector3.new(offsetX * 2, -10, offsetZ * 2)
+	part:SetAttribute("SpawnTime", os.clock())
+	part.Parent = PartStorage
+
+	task.delay(2000, function() if part and part.Parent then part:Destroy() end end)
+end

--- a/Dropper9_NEW.lua
+++ b/Dropper9_NEW.lua
@@ -1,0 +1,63 @@
+--[[
+	Dropper 9 NEW - Neon Blue Fabric
+	Optimized with anti-stack
+--]]
+
+local AntiStack = require(workspace:WaitForChild("DropperAntiStack"))
+
+-- Setup collision groups
+AntiStack.SetupCollisionGroups()
+
+-- Setup player collisions
+game.Players.PlayerAdded:Connect(function(player)
+	player.CharacterAdded:Connect(AntiStack.SetupPlayerCollisions)
+end)
+
+for _, player in ipairs(game.Players:GetPlayers()) do
+	if player.Character then
+		AntiStack.SetupPlayerCollisions(player.Character)
+	end
+end
+
+-- Wait for dependencies
+task.wait(2)
+local PartStorage = workspace:WaitForChild("PartStorage")
+local dropPart = script.Parent:WaitForChild("Drop")
+
+local dropCount = 0
+
+while true do
+	task.wait(0.5)
+	
+	-- Debounce check to prevent spam
+	if not AntiStack.CanDrop(0.45) then
+		continue
+	end
+	
+	dropCount = dropCount + 1
+
+	-- Create part
+	local part = Instance.new("Part")
+	part.Name = "FabricDrop9_" .. dropCount
+	part.BrickColor = BrickColor.new("Really blue")
+	part.Material = "Neon"
+	part.FormFactor = "Custom"
+	part.Size = Vector3.new(1.2, 1.2, 1.2)
+	part.TopSurface = "Smooth"
+	part.BottomSurface = "Smooth"
+
+	-- Cash value
+	local cash = Instance.new("IntValue")
+	cash.Name = "Cash"
+	cash.Value = 180
+	cash.Parent = part
+
+	-- Apply anti-stack physics
+	AntiStack.ApplyAntiStackPhysics(part, dropPart)
+
+	-- Parent to storage
+	part.Parent = PartStorage
+
+	-- Long lifetime
+	AntiStack.ScheduleCleanup(part, 2000)
+end

--- a/Dropper9_NEW.lua
+++ b/Dropper9_NEW.lua
@@ -1,63 +1,64 @@
 --[[
-	Dropper 9 NEW - Neon Blue Fabric
-	Optimized with anti-stack
+	Dropper 9 NEW - Neon Blue
+	Uses DropperCore
 --]]
 
-local AntiStack = require(workspace:WaitForChild("DropperAntiStack"))
+local Core = require(game.ReplicatedStorage.Modules.DropperCore)
 
--- Setup collision groups
-AntiStack.SetupCollisionGroups()
+task.wait(1)
 
--- Setup player collisions
-game.Players.PlayerAdded:Connect(function(player)
-	player.CharacterAdded:Connect(AntiStack.SetupPlayerCollisions)
-end)
+-- Create template model
+local templateModel = Instance.new("Model")
+templateModel.Name = "Dropper9Template"
 
-for _, player in ipairs(game.Players:GetPlayers()) do
-	if player.Character then
-		AntiStack.SetupPlayerCollisions(player.Character)
-	end
+local mainPart = Instance.new("Part")
+mainPart.Name = "PrimaryPart"
+mainPart.Size = Vector3.new(1.2, 1.2, 1.2)
+mainPart.BrickColor = BrickColor.new("Really blue")
+mainPart.Material = Enum.Material.Neon
+mainPart.TopSurface = Enum.SurfaceType.Smooth
+mainPart.BottomSurface = Enum.SurfaceType.Smooth
+mainPart.Transparency = 0
+mainPart.Anchored = false
+mainPart.CanCollide = true
+mainPart.Parent = templateModel
+
+-- Set primary part
+templateModel.PrimaryPart = mainPart
+
+-- Store template
+local templateStorage = game.ReplicatedStorage:FindFirstChild("DropperTemplates")
+if not templateStorage then
+	templateStorage = Instance.new("Folder")
+	templateStorage.Name = "DropperTemplates"
+	templateStorage.Parent = game.ReplicatedStorage
 end
+templateModel.Parent = templateStorage
 
--- Wait for dependencies
-task.wait(2)
-local PartStorage = workspace:WaitForChild("PartStorage")
-local dropPart = script.Parent:WaitForChild("Drop")
+-- Run dropper
+Core.RunModel({
+	model = script.Parent,
+	partStorage = workspace:WaitForChild("PartStorage"),
+	templateModel = templateModel,
 
-local dropCount = 0
+	namePrefix = "Neon9_",
+	dropGroup = "HelloKittyDrops9",
+	playerGroup = "Players",
 
-while true do
-	task.wait(0.5)
+	dropRate = 0.5,
+	cashValue = 180,
+	lifetime = 2000,
+
+	scaleFactor = 1.0,
+	density = 0.3,
+	friction = 0.4,
+	elasticity = 0.1,
 	
-	-- Debounce check to prevent spam
-	if not AntiStack.CanDrop(0.45) then
-		continue
-	end
+	extraLower = 1.5,
+	fadeTime = 0.4,
 	
-	dropCount = dropCount + 1
-
-	-- Create part
-	local part = Instance.new("Part")
-	part.Name = "FabricDrop9_" .. dropCount
-	part.BrickColor = BrickColor.new("Really blue")
-	part.Material = "Neon"
-	part.FormFactor = "Custom"
-	part.Size = Vector3.new(1.2, 1.2, 1.2)
-	part.TopSurface = "Smooth"
-	part.BottomSurface = "Smooth"
-
-	-- Cash value
-	local cash = Instance.new("IntValue")
-	cash.Name = "Cash"
-	cash.Value = 180
-	cash.Parent = part
-
-	-- Apply anti-stack physics
-	AntiStack.ApplyAntiStackPhysics(part, dropPart)
-
-	-- Parent to storage
-	part.Parent = PartStorage
-
-	-- Long lifetime
-	AntiStack.ScheduleCleanup(part, 2000)
-end
+	cashOn = "primary",
+	
+	collectorNames = {"Collector", "CollectorZone", "Receiver", "Sell", "SellPad"},
+	collectorTags = {"Collector", "SellZone"},
+})

--- a/Dropper9_NEW.lua
+++ b/Dropper9_NEW.lua
@@ -1,64 +1,72 @@
+--!strict
 --[[
-	Dropper 9 NEW - Neon Blue
-	Uses DropperCore
+	Dropper 9 NEW - Neon Blue (FIXED)
 --]]
 
-local Core = require(game.ReplicatedStorage.Modules.DropperCore)
+local PhysicsService = game:GetService("PhysicsService")
 
-task.wait(1)
+task.wait(2)
+local PartStorage = workspace:WaitForChild("PartStorage")
+local dropPart = script.Parent:WaitForChild("Drop")
 
--- Create template model
-local templateModel = Instance.new("Model")
-templateModel.Name = "Dropper9Template"
+local ORB_GROUP = "HelloKittyDrops9"
+local PLAYER_GROUP = "Players"
 
-local mainPart = Instance.new("Part")
-mainPart.Name = "PrimaryPart"
-mainPart.Size = Vector3.new(1.2, 1.2, 1.2)
-mainPart.BrickColor = BrickColor.new("Really blue")
-mainPart.Material = Enum.Material.Neon
-mainPart.TopSurface = Enum.SurfaceType.Smooth
-mainPart.BottomSurface = Enum.SurfaceType.Smooth
-mainPart.Transparency = 0
-mainPart.Anchored = false
-mainPart.CanCollide = true
-mainPart.Parent = templateModel
+pcall(function()
+	PhysicsService:RegisterCollisionGroup(ORB_GROUP)
+	PhysicsService:RegisterCollisionGroup(PLAYER_GROUP)
+	PhysicsService:CollisionGroupSetCollidable(ORB_GROUP, PLAYER_GROUP, false)
+	PhysicsService:CollisionGroupSetCollidable(ORB_GROUP, ORB_GROUP, false)
+end)
 
--- Set primary part
-templateModel.PrimaryPart = mainPart
-
--- Store template
-local templateStorage = game.ReplicatedStorage:FindFirstChild("DropperTemplates")
-if not templateStorage then
-	templateStorage = Instance.new("Folder")
-	templateStorage.Name = "DropperTemplates"
-	templateStorage.Parent = game.ReplicatedStorage
+local function setupPlayer(character)
+	task.wait(0.1)
+	for _, part in ipairs(character:GetDescendants()) do
+		if part:IsA("BasePart") then
+			pcall(function() part.CollisionGroup = PLAYER_GROUP end)
+		end
+	end
 end
-templateModel.Parent = templateStorage
 
--- Run dropper
-Core.RunModel({
-	model = script.Parent,
-	partStorage = workspace:WaitForChild("PartStorage"),
-	templateModel = templateModel,
+game.Players.PlayerAdded:Connect(function(player)
+	player.CharacterAdded:Connect(setupPlayer)
+end)
 
-	namePrefix = "Neon9_",
-	dropGroup = "HelloKittyDrops9",
-	playerGroup = "Players",
+for _, player in ipairs(game.Players:GetPlayers()) do
+	if player.Character then setupPlayer(player.Character) end
+end
 
-	dropRate = 0.5,
-	cashValue = 180,
-	lifetime = 2000,
+local dropCount = 0
 
-	scaleFactor = 1.0,
-	density = 0.3,
-	friction = 0.4,
-	elasticity = 0.1,
-	
-	extraLower = 1.5,
-	fadeTime = 0.4,
-	
-	cashOn = "primary",
-	
-	collectorNames = {"Collector", "CollectorZone", "Receiver", "Sell", "SellPad"},
-	collectorTags = {"Collector", "SellZone"},
-})
+while true do
+	task.wait(0.5)
+	dropCount = dropCount + 1
+
+	local part = Instance.new("Part")
+	part.Name = "Neon9_" .. dropCount
+	part.Size = Vector3.new(1.2, 1.2, 1.2)
+	part.BrickColor = BrickColor.new("Really blue")
+	part.Material = Enum.Material.Neon
+	part.TopSurface = Enum.SurfaceType.Smooth
+	part.BottomSurface = Enum.SurfaceType.Smooth
+
+	part.CanCollide = true
+	part.CanTouch = true
+	part.CanQuery = true
+	part.CollisionGroup = ORB_GROUP
+	part.CustomPhysicalProperties = PhysicalProperties.new(0.3, 0.4, 0.1, 1, 1)
+
+	local cash = Instance.new("IntValue")
+	cash.Name = "Cash"
+	cash.Value = 180
+	cash.Parent = part
+
+	local offsetX = math.random(-2, 2) * 0.1
+	local offsetZ = math.random(-2, 2) * 0.1
+	part.CFrame = (dropPart.CFrame - Vector3.new(offsetX, 1.5, offsetZ))
+	part.AssemblyLinearVelocity = Vector3.new(offsetX * 2, -10, offsetZ * 2)
+	part:SetAttribute("SpawnTime", os.clock())
+	part.Parent = PartStorage
+
+	task.delay(2000, function() if part and part.Parent then part:Destroy() end end)
+end

--- a/DropperCore.lua
+++ b/DropperCore.lua
@@ -1,0 +1,414 @@
+--!strict
+-- DropperCore v4.5 — FIXED: Collision Groups + Scaling + Welding + Parent Lock
+
+local TweenService = game:GetService("TweenService")
+local Debris = game:GetService("Debris")
+local PhysicsService = game:GetService("PhysicsService")
+local Players = game:GetService("Players")
+local CollectionService = game:GetService("CollectionService")
+
+local Core = {}
+
+-- Track registered collision groups to avoid re-registration
+local registeredGroups = {}
+
+-- =========================
+-- small utils
+-- =========================
+local function findPrimaryPart(model: Model): BasePart?
+	if model.PrimaryPart then return model.PrimaryPart end
+	local best: BasePart? = nil
+	local vol = -1
+	for _, d in ipairs(model:GetDescendants()) do
+		if d:IsA("BasePart") then
+			local v = d.Size.X * d.Size.Y * d.Size.Z
+			if v > vol then vol = v; best = d end
+		end
+	end
+	return best
+end
+
+local function weldAllParts(model: Model, primary: BasePart)
+	for _, d in ipairs(model:GetDescendants()) do
+		if d:IsA("BasePart") and d ~= primary then
+			local w = Instance.new("WeldConstraint")
+			w.Part0 = primary
+			w.Part1 = d
+			w.Parent = primary
+		end
+	end
+end
+
+local function setupCollisionGroups(dropGroup: string, playerGroup: string)
+	-- Only register each group once
+	if not registeredGroups[dropGroup] then
+		pcall(function()
+			PhysicsService:RegisterCollisionGroup(dropGroup)
+		end)
+		registeredGroups[dropGroup] = true
+	end
+	
+	if not registeredGroups[playerGroup] then
+		pcall(function()
+			PhysicsService:RegisterCollisionGroup(playerGroup)
+		end)
+		registeredGroups[playerGroup] = true
+	end
+	
+	-- Set collision rules (drops don't collide with each other or players)
+	pcall(function() PhysicsService:CollisionGroupSetCollidable(dropGroup, playerGroup, false) end)
+	pcall(function() PhysicsService:CollisionGroupSetCollidable(dropGroup, dropGroup, false) end)
+end
+
+local function tagCharacterPartsAsPlayerGroup(playerGroup: string)
+	local function setChar(char: Model)
+		task.wait(0.1)
+		for _, p in ipairs(char:GetDescendants()) do
+			if p:IsA("BasePart") then
+				pcall(function() p.CollisionGroup = playerGroup end)
+			end
+		end
+	end
+	Players.PlayerAdded:Connect(function(plr)
+		plr.CharacterAdded:Connect(setChar)
+	end)
+	for _, plr in ipairs(Players:GetPlayers()) do
+		if plr.Character then setChar(plr.Character) end
+	end
+end
+
+local function isCollectorPart(hit: Instance?, names: {string}, tags: {string}): boolean
+	local bp = hit
+	if not (bp and bp:IsA("BasePart")) then return false end
+	local n = string.lower(bp.Name)
+	local pn = bp.Parent and string.lower(bp.Parent.Name) or ""
+	for _, want in ipairs(names) do
+		local w = string.lower(want)
+		if n == w or pn == w then return true end
+	end
+	if n:find("collect") or pn:find("collect") or n:find("sell") or pn:find("sell") then
+		return true
+	end
+	for _, t in ipairs(tags) do
+		if CollectionService:HasTag(bp, t) or (bp.Parent and CollectionService:HasTag(bp.Parent, t)) then
+			return true
+		end
+	end
+	if bp:GetAttribute("Collector") == true then return true end
+	if bp.Parent and bp.Parent:FindFirstChild("Collector") then return true end
+	return false
+end
+
+-- =========================
+-- template prep (weld & scale once)
+-- =========================
+local preparedTemplates: { [Model]: Model } = setmetatable({}, { __mode = "k" })
+local function prepareTemplate(src: Model, scale: number): Model
+	local cached = preparedTemplates[src]
+	if cached and cached.Parent == nil then
+		return cached
+	end
+	local m = src:Clone()
+	local primary = findPrimaryPart(m) or m:FindFirstChildWhichIsA("BasePart", true)
+	if primary then m.PrimaryPart = primary end
+	for _, j in ipairs(m:GetDescendants()) do
+		if j:IsA("WeldConstraint") or j:IsA("Motor6D") then j:Destroy() end
+	end
+	if scale ~= 1 then
+		local pivot = m:GetPivot()
+		m:ScaleTo(scale)
+		m:PivotTo(pivot)
+	end
+	if primary then weldAllParts(m, primary) end
+	m.Parent = nil
+	preparedTemplates[src] = m
+	return m
+end
+
+-- =========================
+-- ULTIMATE FIX: Simple fresh model creation
+-- =========================
+local function createFreshDropModel(
+	template: Model,
+	scale: number,
+	dropGroup: string,
+	density: number, friction: number, elasticity: number,
+	cashValue: number, cashOn: "primary" | "all"
+): Model
+	-- Clone the template
+	local model = template:Clone()
+
+	-- Find primary part
+	local primary = findPrimaryPart(model) or model:FindFirstChildWhichIsA("BasePart", true)
+	if primary then model.PrimaryPart = primary end
+
+	-- Remove existing welds
+	for _, j in ipairs(model:GetDescendants()) do
+		if j:IsA("WeldConstraint") or j:IsA("Motor6D") then j:Destroy() end
+	end
+
+	-- Apply scaling
+	if scale ~= 1 then
+		local pivot = model:GetPivot()
+		model:ScaleTo(scale)
+		model:PivotTo(pivot)
+	end
+
+	-- Re-weld all parts to primary
+	if primary then weldAllParts(model, primary) end
+
+	-- Setup all parts with collision group FIRST
+	for _, part in ipairs(model:GetDescendants()) do
+		if part:IsA("BasePart") then
+			part.Anchored = false
+			part.CanTouch = true
+			part.CanQuery = true
+			part.CanCollide = true
+			-- Set collision group (this is critical!)
+			part.CollisionGroup = dropGroup
+			part.CustomPhysicalProperties = PhysicalProperties.new(density, friction, elasticity, 1, 1)
+		end
+	end
+
+	-- Add cash values
+	if cashOn == "primary" then
+		local v = Instance.new("IntValue")
+		v.Name = "Cash"; v.Value = cashValue; v.Parent = primary
+	else
+		for _, part in ipairs(model:GetDescendants()) do
+			if part:IsA("BasePart") then
+				local v = Instance.new("IntValue")
+				v.Name = "Cash"; v.Value = cashValue; v.Parent = part
+			end
+		end
+	end
+
+	return model
+end
+
+-- =========================
+-- PUBLIC: RunModel (fresh models)
+-- =========================
+function Core.RunModel(config: {
+	model: Model,
+	partStorage: Instance,
+	templateModel: Model,
+
+	namePrefix: string?,
+	dropGroup: string?,
+	playerGroup: string?,
+	dropRate: number?,
+	cashValue: number?,
+	lifetime: number?,
+
+	scaleFactor: number?,
+	extraLower: number?,
+	fadeTime: number?,
+	density: number?,
+	friction: number?,
+	elasticity: number?,
+	yawDegrees: number?,
+	cashOn: ("primary" | "all")?,
+
+	collectorNames: {string}?,
+	collectorTags: {string}?,
+	})
+	local dropModel = config.model
+	local dropPart  = dropModel:WaitForChild("Drop") :: BasePart
+	local storage   = config.partStorage
+	local template  = config.templateModel
+	assert(template, "RunModel requires config.templateModel")
+
+	local DROP_RATE   = config.dropRate    or 1.2
+	local CASH_VALUE  = config.cashValue   or 10
+	local SCALE       = config.scaleFactor or 1.0
+	local EXTRA_LOWER = config.extraLower  or 0.35
+	local FADE_TIME   = config.fadeTime    or 0.35
+	local LIFETIME    = config.lifetime
+	local GROUP       = config.dropGroup   or "Drops"
+	local PLAYER_GRP  = config.playerGroup or "Players"
+	local DENSITY     = config.density     or 0.7
+	local FRICTION    = config.friction    or 0.3
+	local ELASTICITY  = config.elasticity  or 0.05
+	local YAW         = config.yawDegrees  or 0
+	local CASH_ON     = config.cashOn      or "primary"
+
+	local collectorNames = config.collectorNames or { "Collector", "CollectorZone", "Receiver", "Sell", "SellPad" }
+	local collectorTags  = config.collectorTags  or { "Collector", "SellZone" }
+	local NAME_PREFIX    = config.namePrefix     or "Drop_"
+
+	setupCollisionGroups(GROUP, PLAYER_GRP)
+	tagCharacterPartsAsPlayerGroup(PLAYER_GRP)
+
+	local count = 0
+	while true do
+		task.wait(DROP_RATE)
+		count += 1
+
+		-- Create fresh model with proper scaling and welding
+		local model = createFreshDropModel(template, SCALE, GROUP, DENSITY, FRICTION, ELASTICITY, CASH_VALUE, CASH_ON)
+		model.Name = NAME_PREFIX .. tostring(count)
+
+		local primary = findPrimaryPart(model) :: BasePart
+		local parts = {}
+		local decals = {}
+
+		-- Collect all parts and decals
+		for _, d in ipairs(model:GetDescendants()) do
+			if d:IsA("BasePart") then
+				table.insert(parts, d)
+			elseif d:IsA("Decal") or d:IsA("Texture") then
+				table.insert(decals, d)
+			end
+		end
+
+		-- Reset physics state
+		primary.AssemblyLinearVelocity = Vector3.zero
+		primary.AssemblyAngularVelocity = Vector3.zero
+
+		-- Add random spread to prevent stacking
+		local offsetX = math.random(-3, 3) * 0.15
+		local offsetZ = math.random(-3, 3) * 0.15
+		local ext = model:GetExtentsSize()
+		local sitY = (ext.Y / 2) - 0.6
+		local spawnPos = dropPart.Position + Vector3.new(-offsetX, -(sitY + EXTRA_LOWER), -offsetZ)
+		local yawOnly = CFrame.Angles(0, math.rad(YAW + math.random(-15, 15)), 0)
+		model:PivotTo(CFrame.new(spawnPos) * yawOnly)
+
+		-- Upright stabilizer
+		do
+			local att = Instance.new("Attachment"); att.Parent = primary
+			local ao  = Instance.new("AlignOrientation")
+			ao.Mode = Enum.OrientationAlignmentMode.OneAttachment
+			ao.Attachment0 = att
+			ao.RigidityEnabled = true
+			ao.Responsiveness = 40
+			ao.CFrame = yawOnly
+			ao.Parent = primary
+			Debris:AddItem(ao, 0.35); Debris:AddItem(att, 0.35)
+		end
+
+		-- Add slight random velocity to spread drops
+		local randVelX = math.random(-2, 2) * 0.5
+		local randVelZ = math.random(-2, 2) * 0.5
+		primary.AssemblyLinearVelocity = Vector3.new(randVelX, -8, randVelZ)
+		primary:SetAttribute("SpawnTime", os.clock())
+
+		-- Set initial transparency
+		for _, p in ipairs(parts) do p.Transparency = 1 end
+		for _, d in ipairs(decals) do
+			if d:IsA("Decal") or d:IsA("Texture") then d.Transparency = 1 end
+		end
+
+		-- Spawn the model
+		model.Parent = storage
+
+		-- Fade in animation
+		local ti = TweenInfo.new(FADE_TIME, Enum.EasingStyle.Quad, Enum.EasingDirection.Out)
+		for i, p in ipairs(parts) do
+			if i <= 12 then
+				TweenService:Create(p, ti, {Transparency = 0}):Play()
+			else
+				p.Transparency = 0
+			end
+		end
+		for i, d in ipairs(decals) do
+			if i <= 12 and (d:IsA("Decal") or d:IsA("Texture")) then
+				TweenService:Create(d, ti, {Transparency = 0}):Play()
+			else
+				if d:IsA("Decal") or d:IsA("Texture") then d.Transparency = 0 end
+			end
+		end
+
+		-- Pop animation
+		do
+			local original = primary.Size
+			primary.Size = Vector3.new(0.1, 0.1, 0.1)
+			TweenService:Create(primary, TweenInfo.new(0.35, Enum.EasingStyle.Back, Enum.EasingDirection.Out), { Size = original }):Play()
+		end
+
+		-- Light flash
+		do
+			local light = Instance.new("PointLight")
+			light.Brightness = 1.2; light.Range = 6; light.Color = Color3.new(1,1,1); light.Parent = primary
+			TweenService:Create(light, TweenInfo.new(0.4, Enum.EasingStyle.Quad, Enum.EasingDirection.Out), { Brightness = 0.4 }):Play()
+			Debris:AddItem(light, 0.6)
+		end
+
+		-- Collection handler
+		local collected = false
+		local connections = {}
+
+		local function collectAndReturn()
+			if collected then return end
+			collected = true
+
+			-- Disconnect all connections
+			for _, conn in ipairs(connections) do
+				if conn.Connected then conn:Disconnect() end
+			end
+
+			-- Anchor and disable physics
+			primary.Anchored = true
+			primary.CanCollide = false
+			primary.CanTouch = false
+
+			-- Fade out animation
+			local fadeOutTi = TweenInfo.new(math.max(FADE_TIME * 0.75, 0.2), Enum.EasingStyle.Quad, Enum.EasingDirection.In)
+			for i, p in ipairs(parts) do
+				if i <= 10 then
+					TweenService:Create(p, fadeOutTi, {Transparency = 1}):Play()
+				else
+					p.Transparency = 1
+				end
+			end
+			for i, d in ipairs(decals) do
+				if i <= 10 and (d:IsA("Decal") or d:IsA("Texture")) then
+					TweenService:Create(d, fadeOutTi, {Transparency = 1}):Play()
+				else
+					if d:IsA("Decal") or d:IsA("Texture") then d.Transparency = 1 end
+				end
+			end
+
+			-- Destroy after fade
+			task.delay(math.max(FADE_TIME * 0.75, 0.2) + 0.1, function()
+				model:Destroy()
+			end)
+		end
+
+		-- Touch detection on PRIMARY part
+		local touchConn = primary.Touched:Connect(function(hit)
+			if collected then return end
+
+			if isCollectorPart(hit, collectorNames, collectorTags) then
+				collectAndReturn()
+			end
+		end)
+		table.insert(connections, touchConn)
+
+		-- BONUS: Also check all parts for touch (more reliable)
+		for _, part in ipairs(parts) do
+			if part ~= primary then
+				local conn = part.Touched:Connect(function(hit)
+					if collected then return end
+					if isCollectorPart(hit, collectorNames, collectorTags) then
+						collectAndReturn()
+					end
+				end)
+				table.insert(connections, conn)
+			end
+		end
+
+		if LIFETIME and LIFETIME > 0 then
+			task.delay(LIFETIME, function()
+				if not collected then collectAndReturn() end
+			end)
+		end
+	end
+end
+
+function Core.Run(_config)
+	error("Core.Run not implemented in v4.5; use RunModel() for model droppers.")
+end
+
+return Core

--- a/HelloKitty_Dropper4_Fixed.lua
+++ b/HelloKitty_Dropper4_Fixed.lua
@@ -58,7 +58,7 @@ Core.RunModel({
 	templateModel = templateModel,
 
 	namePrefix = "WhiteHeart_",
-	dropGroup = "HeartDrops",
+	dropGroup = "HelloKittyDrops4",
 	playerGroup = "Players",
 
 	dropRate = 0.9,

--- a/HelloKitty_Dropper5_Fixed.lua
+++ b/HelloKitty_Dropper5_Fixed.lua
@@ -67,7 +67,7 @@ Core.RunModel({
 	templateModel = templateModel,
 
 	namePrefix = "IceCream_",
-	dropGroup = "IceCreamDrops",
+	dropGroup = "HelloKittyDrops5",
 	playerGroup = "Players",
 
 	dropRate = 1.5,

--- a/HelloKitty_Dropper6_Fixed.lua
+++ b/HelloKitty_Dropper6_Fixed.lua
@@ -49,7 +49,7 @@ Core.RunModel({
 	templateModel = templateModel,
 
 	namePrefix = "Drop6_",
-	dropGroup = "Drops6",
+	dropGroup = "HelloKittyDrops6",
 	playerGroup = "Players",
 
 	dropRate = 1.5,


### PR DESCRIPTION
Fix HelloKitty dropper collisions by assigning unique drop groups and increase cash values for droppers 8-13.

---
<a href="https://cursor.com/background-agent?bcId=bc-d5b6e27b-0f78-4c35-a093-806ca3a9d922"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-d5b6e27b-0f78-4c35-a093-806ca3a9d922"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

