### PR TITLE
Fix shop gui button sizing and feedback

### DIFF
--- a/SanrioShop_Clean.lua
+++ b/SanrioShop_Clean.lua
@@ -1,0 +1,229 @@
+--[[
+    Sanrio Shop GUI — CLEAN SIMPLE VERSION
+    
+    Simple, clean button design with proper images
+    No weird hit testing or complex code
+--]]
+
+local Players = game:GetService("Players")
+local TweenService = game:GetService("TweenService")
+local ReplicatedStorage = game:GetService("ReplicatedStorage")
+
+local player = Players.LocalPlayer
+local pg = player:WaitForChild("PlayerGui")
+
+-- Assets
+local IMG_FRAME = "rbxassetid://83301831904885"
+local IMG_GAMEPASSES = "rbxassetid://137846629770171"
+local IMG_CASH = "rbxassetid://84262748186110"
+
+-- Create ScreenGui
+local gui = Instance.new("ScreenGui")
+gui.Name = "SanrioShop"
+gui.ResetOnSpawn = false
+gui.ZIndexBehavior = Enum.ZIndexBehavior.Sibling
+gui.Parent = pg
+
+-- Main Frame with background
+local mainFrame = Instance.new("ImageLabel")
+mainFrame.Name = "MainFrame"
+mainFrame.Size = UDim2.fromScale(0.8, 0.8)
+mainFrame.Position = UDim2.fromScale(0.5, 0.5)
+mainFrame.AnchorPoint = Vector2.new(0.5, 0.5)
+mainFrame.Image = IMG_FRAME
+mainFrame.ScaleType = Enum.ScaleType.Fit
+mainFrame.BackgroundTransparency = 1
+mainFrame.Parent = gui
+
+-- Keep it square
+local aspect = Instance.new("UIAspectRatioConstraint")
+aspect.AspectRatio = 1
+aspect.Parent = mainFrame
+
+-- Button Container
+local buttonContainer = Instance.new("Frame")
+buttonContainer.Name = "ButtonContainer"
+buttonContainer.Size = UDim2.new(0.8, 0, 0, 100)
+buttonContainer.Position = UDim2.fromScale(0.5, 0.3)
+buttonContainer.AnchorPoint = Vector2.new(0.5, 0.5)
+buttonContainer.BackgroundTransparency = 1
+buttonContainer.Parent = mainFrame
+
+local buttonLayout = Instance.new("UIListLayout")
+buttonLayout.FillDirection = Enum.FillDirection.Horizontal
+buttonLayout.HorizontalAlignment = Enum.HorizontalAlignment.Center
+buttonLayout.VerticalAlignment = Enum.VerticalAlignment.Center
+buttonLayout.Padding = UDim.new(0, 20)
+buttonLayout.Parent = buttonContainer
+
+-- Helper: Create a clean button with image
+local function createButton(name, imageId)
+	-- Container for the button (so image doesn't stretch)
+	local btnContainer = Instance.new("Frame")
+	btnContainer.Name = name .. "Container"
+	btnContainer.Size = UDim2.fromOffset(280, 90)
+	btnContainer.BackgroundTransparency = 1
+	btnContainer.Parent = buttonContainer
+	
+	-- The actual clickable button
+	local btn = Instance.new("TextButton")
+	btn.Name = name .. "Button"
+	btn.Size = UDim2.fromScale(1, 1)
+	btn.BackgroundTransparency = 1
+	btn.Text = ""
+	btn.AutoButtonColor = false
+	btn.Parent = btnContainer
+	
+	-- Image on top
+	local img = Instance.new("ImageLabel")
+	img.Name = "Image"
+	img.Size = UDim2.fromScale(1, 1)
+	img.BackgroundTransparency = 1
+	img.Image = imageId
+	img.ScaleType = Enum.ScaleType.Fit
+	img.Parent = btn
+	
+	-- Simple hover effect
+	local originalSize = btnContainer.Size
+	
+	btn.MouseEnter:Connect(function()
+		TweenService:Create(btnContainer, TweenInfo.new(0.15), {
+			Size = UDim2.fromOffset(290, 95)
+		}):Play()
+	end)
+	
+	btn.MouseLeave:Connect(function()
+		TweenService:Create(btnContainer, TweenInfo.new(0.15), {
+			Size = originalSize
+		}):Play()
+	end)
+	
+	btn.MouseButton1Down:Connect(function()
+		TweenService:Create(btnContainer, TweenInfo.new(0.08), {
+			Size = UDim2.fromOffset(270, 85)
+		}):Play()
+	end)
+	
+	btn.MouseButton1Up:Connect(function()
+		TweenService:Create(btnContainer, TweenInfo.new(0.1), {
+			Size = UDim2.fromOffset(290, 95)
+		}):Play()
+	end)
+	
+	return btn
+end
+
+-- Create buttons
+local cashBtn = createButton("Cash", IMG_CASH)
+local gpBtn = createButton("Gamepasses", IMG_GAMEPASSES)
+
+-- Content area
+local contentFrame = Instance.new("Frame")
+contentFrame.Name = "Content"
+contentFrame.Size = UDim2.new(0.85, 0, 0.5, 0)
+contentFrame.Position = UDim2.fromScale(0.5, 0.65)
+contentFrame.AnchorPoint = Vector2.new(0.5, 0.5)
+contentFrame.BackgroundColor3 = Color3.fromRGB(255, 255, 255)
+contentFrame.BackgroundTransparency = 0.85
+contentFrame.Parent = mainFrame
+
+local contentCorner = Instance.new("UICorner")
+contentCorner.CornerRadius = UDim.new(0, 20)
+contentCorner.Parent = contentFrame
+
+-- Pages
+local cashPage = Instance.new("ScrollingFrame")
+cashPage.Name = "CashPage"
+cashPage.Size = UDim2.fromScale(1, 1)
+cashPage.BackgroundTransparency = 1
+cashPage.BorderSizePixel = 0
+cashPage.ScrollBarThickness = 6
+cashPage.Visible = true
+cashPage.Parent = contentFrame
+
+local cashGrid = Instance.new("UIGridLayout")
+cashGrid.CellSize = UDim2.new(0.48, 0, 0, 120)
+cashGrid.CellPadding = UDim2.fromOffset(15, 15)
+cashGrid.HorizontalAlignment = Enum.HorizontalAlignment.Center
+cashGrid.Parent = cashPage
+
+local gpPage = Instance.new("ScrollingFrame")
+gpPage.Name = "GamepassPage"
+gpPage.Size = UDim2.fromScale(1, 1)
+gpPage.BackgroundTransparency = 1
+gpPage.BorderSizePixel = 0
+gpPage.ScrollBarThickness = 6
+gpPage.Visible = false
+gpPage.Parent = contentFrame
+
+local gpGrid = Instance.new("UIGridLayout")
+gpGrid.CellSize = UDim2.new(0.48, 0, 0, 120)
+gpGrid.CellPadding = UDim2.fromOffset(15, 15)
+gpGrid.HorizontalAlignment = Enum.HorizontalAlignment.Center
+gpGrid.Parent = gpPage
+
+-- Add demo items
+for i = 1, 8 do
+	local card = Instance.new("TextButton")
+	card.Name = "CashCard" .. i
+	card.Text = "💰 " .. (i * 1000) .. " Cash\nR$" .. (i * 10)
+	card.TextSize = 18
+	card.Font = Enum.Font.GothamBold
+	card.TextColor3 = Color3.fromRGB(255, 255, 255)
+	card.BackgroundColor3 = Color3.fromRGB(100, 200, 255)
+	card.AutoButtonColor = false
+	card.Parent = cashPage
+	
+	local corner = Instance.new("UICorner")
+	corner.CornerRadius = UDim.new(0, 12)
+	corner.Parent = card
+	
+	card.MouseButton1Click:Connect(function()
+		print("Clicked Cash Pack " .. i)
+	end)
+end
+
+local passNames = {"Auto-Collect", "2x Cash", "Faster Drops", "VIP Pass", "Boombox", "Extra Slots"}
+for i, name in ipairs(passNames) do
+	local card = Instance.new("TextButton")
+	card.Name = "PassCard" .. i
+	card.Text = "🎫 " .. name .. "\nR$" .. (i * 50)
+	card.TextSize = 18
+	card.Font = Enum.Font.GothamBold
+	card.TextColor3 = Color3.fromRGB(255, 255, 255)
+	card.BackgroundColor3 = Color3.fromRGB(200, 150, 255)
+	card.AutoButtonColor = false
+	card.Parent = gpPage
+	
+	local corner = Instance.new("UICorner")
+	corner.CornerRadius = UDim.new(0, 12)
+	corner.Parent = card
+	
+	card.MouseButton1Click:Connect(function()
+		print("Clicked Gamepass: " .. name)
+	end)
+end
+
+-- Button clicks
+cashBtn.MouseButton1Click:Connect(function()
+	cashPage.Visible = true
+	gpPage.Visible = false
+	print("💰 Cash tab")
+end)
+
+gpBtn.MouseButton1Click:Connect(function()
+	cashPage.Visible = false
+	gpPage.Visible = true
+	print("🎫 Gamepasses tab")
+end)
+
+-- Auto-resize canvas
+cashGrid:GetPropertyChangedSignal("AbsoluteContentSize"):Connect(function()
+	cashPage.CanvasSize = UDim2.new(0, 0, 0, cashGrid.AbsoluteContentSize.Y + 20)
+end)
+
+gpGrid:GetPropertyChangedSignal("AbsoluteContentSize"):Connect(function()
+	gpPage.CanvasSize = UDim2.new(0, 0, 0, gpGrid.AbsoluteContentSize.Y + 20)
+end)
+
+print("✅ [SanrioShop] Clean version loaded!")

--- a/SanrioShop_Clean.lua
+++ b/SanrioShop_Clean.lua
@@ -80,7 +80,7 @@ local function createButton(name, imageId)
 	img.Size = UDim2.fromScale(1, 1)
 	img.BackgroundTransparency = 1
 	img.Image = imageId
-	img.ScaleType = Enum.ScaleType.Fit
+	img.ScaleType = Enum.ScaleType.Crop
 	img.Parent = btn
 	
 	-- Simple hover effect

--- a/SanrioShop_Final.lua
+++ b/SanrioShop_Final.lua
@@ -1,0 +1,681 @@
+--[[
+    SANRIO SHOP — FINAL MERGED VERSION
+    Clean pill buttons + Full shop functionality
+    ✨ Mobile-optimized, sales features, gift box, confetti, toggles
+--]]
+
+local Players = game:GetService("Players")
+local MarketplaceService = game:GetService("MarketplaceService")
+local TweenService = game:GetService("TweenService")
+local UserInputService = game:GetService("UserInputService")
+local GuiService = game:GetService("GuiService")
+local ReplicatedStorage = game:GetService("ReplicatedStorage")
+local ContentProvider = game:GetService("ContentProvider")
+local SoundService = game:GetService("SoundService")
+local Lighting = game:GetService("Lighting")
+local RunService = game:GetService("RunService")
+
+local Player = Players.LocalPlayer
+local PlayerGui = Player:WaitForChild("PlayerGui")
+local Remotes = ReplicatedStorage:FindFirstChild("TycoonRemotes")
+
+-- ======== ASSETS ========
+local IMG_FRAME = "rbxassetid://83301831904885"
+local IMG_GAMEPASSES = "rbxassetid://137846629770171"
+local IMG_CASH = "rbxassetid://84262748186110"
+local GIFT_BOX_TEXTURE_ID = "130623477775352" -- ← YOUR GIFT BOX
+
+-- ======== CORE UTILS ========
+local function isMobile() return UserInputService.TouchEnabled and not GuiService:IsTenFootInterface() end
+local function isPhone() if not isMobile() then return false end; local cam=workspace.CurrentCamera; local v=cam.ViewportSize; return math.min(v.X,v.Y)<700 end
+local function formatNumber(n) local s=tostring(n); local k=1; while k~=0 do s,k=s:gsub("^(-?%d+)(%d%d%d)","%1,%2") end; return s end
+local function blend(a,b,t) t=math.clamp(t,0,1); return Color3.new(a.R+(b.R-a.R)*t,a.G+(b.G-a.G)*t,a.B+(b.B-a.B)*t) end
+
+-- ======== DATA ========
+local products = {
+	cash = {
+		{ id = 3366419712, amount = 1000,    name = "1,000 Cash",    description = "Includes 1,000 Cash",    icon = "rbxassetid://10709728059", price = 0 },
+		{ id = 3366420012, amount = 5000,    name = "5,000 Cash",    description = "Includes 5,000 Cash",    icon = "rbxassetid://10709728059", price = 0 },
+		{ id = 3366420478, amount = 10000,   name = "10,000 Cash",   description = "Includes 10,000 Cash",   icon = "rbxassetid://10709728059", price = 0, bonus = 0.10 },
+		{ id = 3366420800, amount = 25000,   name = "25,000 Cash",   description = "Includes 25,000 Cash",   icon = "rbxassetid://10709728059", price = 0 },
+		{ id = 3424973374, amount = 50000,   name = "50,000 Cash",   description = "Includes 50,000 Cash",   icon = "rbxassetid://10709728059", price = 0, bonus = 0.25 },
+		{ id = 3424974046, amount = 100000,  name = "100,000 Cash",  description = "Includes 100,000 Cash",  icon = "rbxassetid://10709728059", price = 0 },
+		{ id = 3424974161, amount = 250000,  name = "250,000 Cash",  description = "Includes 250,000 Cash",  icon = "rbxassetid://10709728059", price = 0 },
+		{ id = 3424974327, amount = 500000,  name = "500,000 Cash",  description = "Includes 500,000 Cash",  icon = "rbxassetid://10709728059", price = 0 },
+		{ id = 3424974402, amount = 1000000, name = "1,000,000 Cash",description = "Includes 1,000,000 Cash",icon = "rbxassetid://10709728059", price = 0, best = true, bonus = 0.35 },
+	},
+	gamepasses = {
+		{ id = 1412171840, name = "Auto Collect", description = "Automatically collect all cash drops", icon = "rbxassetid://10709727148", price = 99,  hasToggle = true  },
+		{ id = 1398974710, name = "2x Cash",      description = "Double all cash earned permanently",   icon = "rbxassetid://10709727148", price = 199, hasToggle = false },
+	},
+}
+
+-- ======== CACHE ========
+local Cache = {}; Cache.__index = Cache
+function Cache.new(d) return setmetatable({data={},duration=d or 300},Cache) end
+function Cache:set(k,v) self.data[k]={v=v,t=tick()} end
+function Cache:get(k) local e=self.data[k]; if not e then return end; if tick()-e.t>self.duration then self.data[k]=nil; return end; return e.v end
+function Cache:clear(k) if k then self.data[k]=nil else self.data={} end end
+
+local productCache = Cache.new(300)
+local ownershipCache = Cache.new(60)
+
+local function getProductInfo(id)
+	local c=productCache:get(id); if c then return c end
+	local ok,info=pcall(function() return MarketplaceService:GetProductInfo(id,Enum.InfoType.Product) end)
+	if ok and info then productCache:set(id,info); return info end
+end
+
+local function getGamePassInfo(id)
+	local key="pass_"..id; local c=productCache:get(key); if c then return c end
+	local ok,info=pcall(function() return MarketplaceService:GetProductInfo(id,Enum.InfoType.GamePass) end)
+	if ok and info then productCache:set(key,info); return info end
+end
+
+local function checkOwnership(passId)
+	local key=("%d_%d"):format(Player.UserId,passId); local c=ownershipCache:get(key); if c~=nil then return c end
+	local ok,owns=pcall(function() return MarketplaceService:UserOwnsGamePassAsync(Player.UserId,passId) end)
+	if ok then ownershipCache:set(key,owns); return owns end; return false
+end
+
+local function refreshPrices()
+	for _,p in ipairs(products.cash) do local i=getProductInfo(p.id); if i and i.PriceInRobux then p.price=i.PriceInRobux end end
+	for _,gp in ipairs(products.gamepasses) do local i=getGamePassInfo(gp.id); if i and i.PriceInRobux then gp.price=i.PriceInRobux end end
+end
+
+-- ======== THEME ========
+local theme = {
+	background = Color3.fromRGB(253,252,250),
+	surface = Color3.fromRGB(255,255,255),
+	surfaceAlt = Color3.fromRGB(246,248,252),
+	stroke = Color3.fromRGB(222,226,235),
+	text = Color3.fromRGB(35,38,46),
+	textSecondary = Color3.fromRGB(120,126,140),
+	accent = Color3.fromRGB(255,80,140),
+	success = Color3.fromRGB(76,175,80),
+	cinna = Color3.fromRGB(186,214,255),
+	kuromi = Color3.fromRGB(200,190,255),
+}
+
+-- ======== SOUND ========
+local sounds = {}
+local function initSound()
+	local cfg={click={"rbxassetid://876939830",0.45},hover={"rbxassetid://10066936758",0.2},open={"rbxassetid://452267918",0.5},success={"rbxassetid://876939830",0.6}}
+	for name,data in pairs(cfg) do local s=Instance.new("Sound"); s.Name="SS_"..name; s.SoundId=data[1]; s.Volume=data[2]; s.Parent=SoundService; sounds[name]=s end
+end
+local function playSound(n) if sounds[n] then sounds[n]:Play() end end
+
+-- ======== EFFECTS ========
+local function pulse(frame)
+	local s=frame:FindFirstChildOfClass("UIScale") or Instance.new("UIScale"); s.Parent=frame
+	TweenService:Create(s,TweenInfo.new(0.1),{Scale=1.06}):Play(); task.delay(0.1,function() TweenService:Create(s,TweenInfo.new(0.18),{Scale=1}):Play() end)
+end
+
+local function confetti(parent)
+	for i=1,8 do
+		local chip=Instance.new("Frame"); chip.BackgroundColor3=(i%2==0) and theme.accent or theme.kuromi; chip.Size=UDim2.fromOffset(6,10); chip.Position=UDim2.new(math.random(),0,0,-6); chip.BorderSizePixel=0; chip.Parent=parent
+		local c=Instance.new("UICorner"); c.CornerRadius=UDim.new(0,2); c.Parent=chip
+		task.spawn(function() TweenService:Create(chip,TweenInfo.new(0.45),{Position=UDim2.new(chip.Position.X.Scale,(math.random()-0.5)*60,0,math.random(60,110)),Rotation=math.random(-40,40)}):Play(); task.delay(0.46,function() chip:Destroy() end) end)
+	end
+end
+
+-- ======== SHOP CLASS ========
+local Shop = {}
+Shop.__index = Shop
+
+function Shop.new()
+	local self = setmetatable({}, Shop)
+	self.gui = nil
+	self.mainFrame = nil
+	self.buttonBar = nil
+	self.contentFrame = nil
+	self.currentTab = "Cash"
+	self.cashBtn = nil
+	self.gpBtn = nil
+	self.cashPage = nil
+	self.gpPage = nil
+	self.toggleButton = nil
+	self.blur = nil
+	self.isOpen = false
+	self.purchasePending = {}
+	return self
+end
+
+function Shop:initialize()
+	initSound()
+	refreshPrices()
+	self:createToggleButton()
+	self:createMainInterface()
+	self:setupHandlers()
+	print("[SanrioShop] ✅ Initialized!")
+end
+
+function Shop:createToggleButton()
+	local sg = Instance.new("ScreenGui")
+	sg.Name = "SanrioShopToggle"
+	sg.ResetOnSpawn = false
+	sg.DisplayOrder = 999
+	sg.ScreenInsets = Enum.ScreenInsets.DeviceSafeInsets
+	sg.Parent = PlayerGui
+
+	local size = isPhone() and UDim2.fromOffset(70,70) or UDim2.fromOffset(90,90)
+	local pos = isPhone() and UDim2.new(1,-16,0,76) or UDim2.new(1,-16,0.5,-70)
+	local anchor = isPhone() and Vector2.new(1,0) or Vector2.new(1,0.5)
+
+	self.toggleButton = Instance.new("TextButton")
+	self.toggleButton.Size = size
+	self.toggleButton.Position = pos
+	self.toggleButton.AnchorPoint = anchor
+	self.toggleButton.BackgroundColor3 = theme.surface
+	self.toggleButton.Text = ""
+	self.toggleButton.AutoButtonColor = false
+	self.toggleButton.Parent = sg
+
+	local corner = Instance.new("UICorner"); corner.CornerRadius = UDim.new(0,16); corner.Parent = self.toggleButton
+	local stroke = Instance.new("UIStroke"); stroke.Color = theme.accent; stroke.Thickness = 2; stroke.Parent = self.toggleButton
+
+	local giftSize = isPhone() and 56 or 72
+	local img = Instance.new("ImageLabel")
+	img.Image = "rbxassetid://" .. GIFT_BOX_TEXTURE_ID
+	img.Size = UDim2.fromOffset(giftSize, giftSize)
+	img.Position = UDim2.fromScale(0.5, 0.5)
+	img.AnchorPoint = Vector2.new(0.5, 0.5)
+	img.BackgroundTransparency = 1
+	img.Parent = self.toggleButton
+
+	self.toggleButton.MouseButton1Click:Connect(function() self:toggle() end)
+end
+
+function Shop:createMainInterface()
+	-- Main ScreenGui
+	self.gui = Instance.new("ScreenGui")
+	self.gui.Name = "SanrioShopMain"
+	self.gui.ResetOnSpawn = false
+	self.gui.DisplayOrder = 1000
+	self.gui.Enabled = false
+	self.gui.IgnoreGuiInset = true
+	self.gui.Parent = PlayerGui
+
+	-- Blur
+	self.blur = Lighting:FindFirstChild("SanrioShopBlur") or Instance.new("BlurEffect")
+	self.blur.Name = "SanrioShopBlur"
+	self.blur.Size = 0
+	self.blur.Parent = Lighting
+
+	-- Dim background
+	local dim = Instance.new("Frame")
+	dim.Size = UDim2.fromScale(1, 1)
+	dim.BackgroundColor3 = Color3.new(0, 0, 0)
+	dim.BackgroundTransparency = 0.38
+	dim.BorderSizePixel = 0
+	dim.Parent = self.gui
+
+	-- Main frame with background image
+	self.mainFrame = Instance.new("ImageLabel")
+	self.mainFrame.Name = "MainFrame"
+	self.mainFrame.Size = UDim2.fromScale(0.75, 0.75)
+	self.mainFrame.Position = UDim2.fromScale(0.5, 0.5)
+	self.mainFrame.AnchorPoint = Vector2.new(0.5, 0.5)
+	self.mainFrame.Image = IMG_FRAME
+	self.mainFrame.ScaleType = Enum.ScaleType.Fit
+	self.mainFrame.BackgroundTransparency = 1
+	self.mainFrame.Parent = self.gui
+
+	local aspect = Instance.new("UIAspectRatioConstraint")
+	aspect.AspectRatio = 1
+	aspect.Parent = self.mainFrame
+
+	-- Button bar (for pill buttons)
+	self.buttonBar = Instance.new("Frame")
+	self.buttonBar.Name = "ButtonBar"
+	self.buttonBar.BackgroundTransparency = 1
+	self.buttonBar.AnchorPoint = Vector2.new(0.5, 0)
+	self.buttonBar.Position = UDim2.fromScale(0.5, 0.30) -- Positioned nicely under header
+	self.buttonBar.Size = UDim2.fromScale(0.80, 0) -- Height set dynamically
+	self.buttonBar.Parent = self.mainFrame
+
+	local buttonLayout = Instance.new("UIListLayout")
+	buttonLayout.FillDirection = Enum.FillDirection.Horizontal
+	buttonLayout.HorizontalAlignment = Enum.HorizontalAlignment.Center
+	buttonLayout.VerticalAlignment = Enum.VerticalAlignment.Center
+	buttonLayout.Padding = UDim.new(0, 18)
+	buttonLayout.Parent = self.buttonBar
+
+	-- Create pill buttons
+	self.cashBtn = self:createPillButton("Cash", IMG_CASH, self.buttonBar)
+	self.gpBtn = self:createPillButton("Gamepasses", IMG_GAMEPASSES, self.buttonBar)
+
+	-- Content area
+	self.contentFrame = Instance.new("Frame")
+	self.contentFrame.Name = "Content"
+	self.contentFrame.AnchorPoint = Vector2.new(0.5, 0)
+	self.contentFrame.Position = UDim2.fromScale(0.5, 0.50) -- Below buttons
+	self.contentFrame.Size = UDim2.fromScale(0.85, 0.42)
+	self.contentFrame.BackgroundColor3 = Color3.fromRGB(255, 255, 255)
+	self.contentFrame.BackgroundTransparency = 0.88
+	self.contentFrame.BorderSizePixel = 0
+	self.contentFrame.Parent = self.mainFrame
+
+	local contentCorner = Instance.new("UICorner")
+	contentCorner.CornerRadius = UDim.new(0, 20)
+	contentCorner.Parent = self.contentFrame
+
+	-- Pages
+	self:createPages()
+
+	-- Dynamic sizing
+	self:setupDynamicSizing()
+end
+
+function Shop:createPillButton(name, imageId, parent)
+	local container = Instance.new("Frame")
+	container.Name = name .. "Container"
+	container.BackgroundTransparency = 1
+	container.Size = UDim2.fromOffset(240, 80) -- Placeholder
+	container.Parent = parent
+
+	local btn = Instance.new("ImageButton")
+	btn.Name = name .. "Button"
+	btn.Size = UDim2.fromScale(1, 1)
+	btn.BackgroundTransparency = 1
+	btn.Image = imageId
+	btn.ScaleType = Enum.ScaleType.Crop
+	btn.AutoButtonColor = false
+	btn.Parent = container
+
+	-- Hover effects
+	local function bump(mult)
+		local sx = math.floor(container.Size.X.Offset * mult)
+		local sy = math.floor(container.Size.Y.Offset * mult)
+		TweenService:Create(container, TweenInfo.new(0.12), {Size = UDim2.fromOffset(sx, sy)}):Play()
+	end
+
+	btn.MouseEnter:Connect(function() playSound("hover"); bump(1.02) end)
+	btn.MouseLeave:Connect(function() bump(1.00) end)
+	btn.MouseButton1Down:Connect(function() bump(0.98) end)
+	btn.MouseButton1Up:Connect(function() bump(1.02) end)
+
+	btn.MouseButton1Click:Connect(function()
+		playSound("click")
+		if name == "Cash" then
+			self:showCash()
+		else
+			self:showGamepasses()
+		end
+	end)
+
+	return container
+end
+
+function Shop:createPages()
+	-- Cash page
+	self.cashPage = Instance.new("ScrollingFrame")
+	self.cashPage.Name = "CashPage"
+	self.cashPage.Size = UDim2.fromScale(1, 1)
+	self.cashPage.BackgroundTransparency = 1
+	self.cashPage.BorderSizePixel = 0
+	self.cashPage.ScrollBarThickness = 6
+	self.cashPage.ScrollBarImageColor3 = theme.accent
+	self.cashPage.Visible = true
+	self.cashPage.Parent = self.contentFrame
+
+	local cashGrid = Instance.new("UIGridLayout")
+	cashGrid.CellSize = UDim2.new(0.48, 0, 0, 110)
+	cashGrid.CellPadding = UDim2.fromOffset(12, 12)
+	cashGrid.HorizontalAlignment = Enum.HorizontalAlignment.Center
+	cashGrid.SortOrder = Enum.SortOrder.LayoutOrder
+	cashGrid.Parent = self.cashPage
+
+	cashGrid:GetPropertyChangedSignal("AbsoluteContentSize"):Connect(function()
+		self.cashPage.CanvasSize = UDim2.new(0, 0, 0, cashGrid.AbsoluteContentSize.Y + 20)
+	end)
+
+	for _, p in ipairs(products.cash) do
+		self:createProductCard(p, "cash", self.cashPage)
+	end
+
+	-- Gamepasses page
+	self.gpPage = Instance.new("ScrollingFrame")
+	self.gpPage.Name = "GamepassPage"
+	self.gpPage.Size = UDim2.fromScale(1, 1)
+	self.gpPage.BackgroundTransparency = 1
+	self.gpPage.BorderSizePixel = 0
+	self.gpPage.ScrollBarThickness = 6
+	self.gpPage.ScrollBarImageColor3 = theme.accent
+	self.gpPage.Visible = false
+	self.gpPage.Parent = self.contentFrame
+
+	local gpGrid = Instance.new("UIGridLayout")
+	gpGrid.CellSize = UDim2.new(0.48, 0, 0, 110)
+	gpGrid.CellPadding = UDim2.fromOffset(12, 12)
+	gpGrid.HorizontalAlignment = Enum.HorizontalAlignment.Center
+	gpGrid.SortOrder = Enum.SortOrder.LayoutOrder
+	gpGrid.Parent = self.gpPage
+
+	gpGrid:GetPropertyChangedSignal("AbsoluteContentSize"):Connect(function()
+		self.gpPage.CanvasSize = UDim2.new(0, 0, 0, gpGrid.AbsoluteContentSize.Y + 20)
+	end)
+
+	for _, gp in ipairs(products.gamepasses) do
+		self:createProductCard(gp, "gamepass", self.gpPage)
+	end
+end
+
+function Shop:createProductCard(product, productType, parent)
+	local isGamepass = (productType == "gamepass")
+	local cardColor = isGamepass and theme.kuromi or theme.cinna
+
+	local card = Instance.new("TextButton")
+	card.Name = product.name .. "Card"
+	card.BackgroundColor3 = theme.surface
+	card.BorderSizePixel = 0
+	card.AutoButtonColor = false
+	card.Text = ""
+	card.Parent = parent
+
+	local corner = Instance.new("UICorner"); corner.CornerRadius = UDim.new(0, 12); corner.Parent = card
+	local stroke = Instance.new("UIStroke"); stroke.Color = cardColor; stroke.Thickness = 2; stroke.Transparency = 0.5; stroke.Parent = card
+
+	-- Title
+	local title = Instance.new("TextLabel")
+	title.Size = UDim2.new(1, -16, 0, 24)
+	title.Position = UDim2.fromOffset(8, 8)
+	title.BackgroundTransparency = 1
+	title.Text = product.name
+	title.TextColor3 = theme.text
+	title.Font = Enum.Font.GothamBold
+	title.TextSize = 16
+	title.TextXAlignment = Enum.TextXAlignment.Left
+	title.TextTruncate = Enum.TextTruncate.AtEnd
+	title.Parent = card
+
+	-- Description
+	local desc = Instance.new("TextLabel")
+	desc.Size = UDim2.new(1, -16, 0, 32)
+	desc.Position = UDim2.fromOffset(8, 34)
+	desc.BackgroundTransparency = 1
+	desc.Text = isGamepass and product.description or (formatNumber(product.amount) .. " Cash")
+	desc.TextColor3 = theme.textSecondary
+	desc.Font = Enum.Font.Gotham
+	desc.TextSize = 13
+	desc.TextXAlignment = Enum.TextXAlignment.Left
+	desc.TextWrapped = true
+	desc.TextYAlignment = Enum.TextYAlignment.Top
+	desc.Parent = card
+
+	-- Price + Button
+	local btnY = isGamepass and 70 or 66
+	local owned = isGamepass and checkOwnership(product.id)
+
+	local buyBtn = Instance.new("TextButton")
+	buyBtn.Size = UDim2.new(1, -16, 0, 32)
+	buyBtn.Position = UDim2.fromOffset(8, btnY)
+	buyBtn.BackgroundColor3 = owned and theme.success or cardColor
+	buyBtn.Text = owned and "✓ Owned" or ("R$" .. tostring(product.price or 0))
+	buyBtn.TextColor3 = Color3.new(1, 1, 1)
+	buyBtn.Font = Enum.Font.GothamBold
+	buyBtn.TextSize = 15
+	buyBtn.AutoButtonColor = false
+	buyBtn.Active = not owned
+	buyBtn.Parent = card
+
+	local btnCorner = Instance.new("UICorner"); btnCorner.CornerRadius = UDim.new(0, 8); btnCorner.Parent = buyBtn
+
+	buyBtn.MouseButton1Click:Connect(function()
+		if owned then return end
+		buyBtn.Text = "..."
+		buyBtn.Active = false
+		self:promptPurchase(product, productType, buyBtn)
+	end)
+
+	-- Toggle for Auto Collect
+	if isGamepass and product.hasToggle and owned then
+		self:addToggleSwitch(product, card)
+	end
+
+	product.cardInstance = card
+	product.purchaseButton = buyBtn
+end
+
+function Shop:addToggleSwitch(product, card)
+	local toggle = Instance.new("Frame")
+	toggle.Name = "Toggle"
+	toggle.Size = UDim2.fromOffset(140, 28)
+	toggle.Position = UDim2.new(1, -8, 0, 8)
+	toggle.AnchorPoint = Vector2.new(1, 0)
+	toggle.BackgroundColor3 = theme.surface
+	toggle.BorderSizePixel = 0
+	toggle.Parent = card
+
+	local toggleCorner = Instance.new("UICorner"); toggleCorner.CornerRadius = UDim.new(0, 14); toggleCorner.Parent = toggle
+	local toggleStroke = Instance.new("UIStroke"); toggleStroke.Color = theme.stroke; toggleStroke.Thickness = 1; toggleStroke.Parent = toggle
+
+	local label = Instance.new("TextLabel")
+	label.Size = UDim2.fromScale(1, 1)
+	label.BackgroundTransparency = 1
+	label.Text = "Auto: OFF"
+	label.TextColor3 = theme.text
+	label.Font = Enum.Font.GothamBold
+	label.TextSize = 12
+	label.Parent = toggle
+
+	local btn = Instance.new("TextButton")
+	btn.Size = UDim2.fromScale(1, 1)
+	btn.BackgroundTransparency = 1
+	btn.Text = ""
+	btn.Parent = toggle
+
+	local state = false
+	if Remotes then
+		local rf = Remotes:FindFirstChild("GetAutoCollectState")
+		if rf and rf:IsA("RemoteFunction") then
+			local ok, val = pcall(function() return rf:InvokeServer() end)
+			if ok and type(val) == "boolean" then state = val end
+		end
+	end
+
+	local function paint(on)
+		state = on
+		if on then
+			toggle.BackgroundColor3 = theme.success
+			toggleStroke.Color = theme.success
+			label.TextColor3 = Color3.new(1, 1, 1)
+			label.Text = "Auto: ON"
+		else
+			toggle.BackgroundColor3 = theme.surface
+			toggleStroke.Color = theme.stroke
+			label.TextColor3 = theme.text
+			label.Text = "Auto: OFF"
+		end
+	end
+
+	paint(state)
+
+	btn.MouseButton1Click:Connect(function()
+		local nextState = not state
+		paint(nextState)
+		playSound("click")
+		if Remotes then
+			local ev = Remotes:FindFirstChild("AutoCollectToggle")
+			if ev and ev:IsA("RemoteEvent") then ev:FireServer(nextState) end
+		end
+	end)
+end
+
+function Shop:setupDynamicSizing()
+	local function resize()
+		local H = self.mainFrame.AbsoluteSize.Y
+		if H <= 0 then return end
+
+		-- Button sizing: 7% of frame height, clamped
+		local btnH = math.clamp(math.floor(H * 0.075), 65, 95)
+		local cashW = math.floor(btnH * 3.2) -- aspect ratio for cash
+		local gpW = math.floor(btnH * 3.5)   -- slightly wider for gamepasses
+
+		self.buttonBar.Size = UDim2.new(0.80, 0, 0, btnH)
+
+		self.cashBtn.Size = UDim2.fromOffset(cashW, btnH)
+		self.gpBtn.Size = UDim2.fromOffset(gpW, btnH)
+	end
+
+	self.mainFrame:GetPropertyChangedSignal("AbsoluteSize"):Connect(resize)
+	RunService.Heartbeat:Connect(resize)
+	task.defer(resize)
+end
+
+function Shop:showCash()
+	self.cashPage.Visible = true
+	self.gpPage.Visible = false
+	self.currentTab = "Cash"
+end
+
+function Shop:showGamepasses()
+	self.cashPage.Visible = false
+	self.gpPage.Visible = true
+	self.currentTab = "Gamepasses"
+end
+
+function Shop:promptPurchase(product, kind, button)
+	self.purchasePending[product.id] = { product = product, type = kind, button = button }
+	local ok
+	if kind == "gamepass" then
+		ok = pcall(function() MarketplaceService:PromptGamePassPurchase(Player, product.id) end)
+	else
+		ok = pcall(function() MarketplaceService:PromptProductPurchase(Player, product.id) end)
+	end
+	if not ok then
+		if button and button.Parent then
+			button.Text = "R$" .. tostring(product.price or 0)
+			button.Active = true
+		end
+		self.purchasePending[product.id] = nil
+	end
+end
+
+function Shop:refreshAllProducts()
+	ownershipCache:clear()
+	for _, gp in ipairs(products.gamepasses) do
+		local owned = checkOwnership(gp.id)
+		if gp.purchaseButton then
+			gp.purchaseButton.Text = owned and "✓ Owned" or ("R$" .. tostring(gp.price or 0))
+			gp.purchaseButton.BackgroundColor3 = owned and theme.success or theme.kuromi
+			gp.purchaseButton.Active = not owned
+		end
+	end
+end
+
+function Shop:open()
+	if self.isOpen then return end
+	self.isOpen = true
+	ownershipCache:clear()
+	refreshPrices()
+	self:refreshAllProducts()
+
+	self.gui.Enabled = true
+	TweenService:Create(self.blur, TweenInfo.new(0.25), {Size = 24}):Play()
+
+	self.mainFrame.Position = UDim2.fromScale(0.5, 0.52)
+	local sz = self.mainFrame.Size
+	self.mainFrame.Size = UDim2.new(sz.X.Scale * 0.94, 0, sz.Y.Scale * 0.94, 0)
+	TweenService:Create(self.mainFrame, TweenInfo.new(0.3, Enum.EasingStyle.Back), {
+		Position = UDim2.fromScale(0.5, 0.5),
+		Size = sz
+	}):Play()
+
+	self:showCash()
+	playSound("open")
+end
+
+function Shop:close()
+	if not self.isOpen then return end
+	self.isOpen = false
+	TweenService:Create(self.blur, TweenInfo.new(0.15), {Size = 0}):Play()
+	TweenService:Create(self.mainFrame, TweenInfo.new(0.15), {
+		Position = UDim2.fromScale(0.5, 0.52),
+		Size = UDim2.new(self.mainFrame.Size.X.Scale * 0.94, 0, self.mainFrame.Size.Y.Scale * 0.94, 0)
+	}):Play()
+	task.wait(0.15)
+	self.gui.Enabled = false
+end
+
+function Shop:toggle()
+	if self.isOpen then
+		self:close()
+	else
+		self:open()
+	end
+end
+
+function Shop:setupHandlers()
+	-- Input
+	UserInputService.InputBegan:Connect(function(i, gp)
+		if gp then return end
+		if i.KeyCode == Enum.KeyCode.M then self:toggle() end
+		if i.KeyCode == Enum.KeyCode.Escape and self.isOpen then self:close() end
+	end)
+
+	-- Remotes
+	if Remotes then
+		local gpPurchased = Remotes:FindFirstChild("GamepassPurchased")
+		if gpPurchased and gpPurchased:IsA("RemoteEvent") then
+			gpPurchased.OnClientEvent:Connect(function()
+				task.wait(0.5)
+				self:refreshAllProducts()
+				playSound("success")
+			end)
+		end
+	end
+
+	-- Purchase callbacks
+	MarketplaceService.PromptGamePassPurchaseFinished:Connect(function(player, passId, purchased)
+		if player ~= Player then return end
+		local p = self.purchasePending[passId]
+		if p and p.button and p.button.Parent then
+			p.button.Text = purchased and "✓ Owned" or ("R$" .. tostring(p.product.price or 0))
+			p.button.Active = not purchased
+		end
+		self.purchasePending[passId] = nil
+		if purchased then
+			ownershipCache:clear()
+			task.wait(0.8)
+			self:refreshAllProducts()
+			playSound("success")
+			if p and p.product and p.product.cardInstance then
+				pulse(p.product.cardInstance)
+				confetti(p.product.cardInstance)
+			end
+		end
+	end)
+
+	MarketplaceService.PromptProductPurchaseFinished:Connect(function(player, productId, purchased)
+		if player ~= Player then return end
+		local p = self.purchasePending[productId]
+		if p and p.button and p.button.Parent then
+			p.button.Text = "R$" .. tostring(p.product.price or 0)
+			p.button.Active = true
+		end
+		self.purchasePending[productId] = nil
+		if purchased then
+			playSound("success")
+			if p and p.product and p.product.cardInstance then
+				pulse(p.product.cardInstance)
+				confetti(p.product.cardInstance)
+			end
+		end
+	end)
+end
+
+-- ======== BOOT ========
+local shop = Shop.new()
+shop:initialize()
+
+Player.CharacterAdded:Connect(function()
+	task.wait(1)
+	if not shop.toggleButton or not shop.toggleButton.Parent then
+		shop:createToggleButton()
+	end
+end)
+
+print("[SanrioShop] ✅ Final merged version loaded!")
+print("[SanrioShop] 🎁 Gift box texture:", GIFT_BOX_TEXTURE_ID)
+return shop

--- a/SanrioShop_Fixed.lua
+++ b/SanrioShop_Fixed.lua
@@ -1,0 +1,449 @@
+--[[
+    Sanrio Shop GUI — FIXED SIZING (v3.6)
+    
+    ✅ FIXES:
+    • Reduced pill button size from 14% to 8% of frame height
+    • Fixed tabs container width to scale properly
+    • Better positioning under the shop header
+    • Proper spacing between buttons
+    • Buttons now properly sized and not stretched
+    
+    Art:
+      • Main frame (1024x1024): rbxassetid://83301831904885
+      • GAMEPASSES pill:       rbxassetid://137846629770171
+      • CASH pill:             rbxassetid://84262748186110
+--]]
+
+--// Services
+local Players       = game:GetService("Players")
+local GuiService    = game:GetService("GuiService")
+local TweenService  = game:GetService("TweenService")
+local RunService    = game:GetService("RunService")
+local UserInputService = game:GetService("UserInputService")
+local ReplicatedStorage = game:GetService("ReplicatedStorage")
+
+--// Assets
+local IMG_FRAME      = "rbxassetid://83301831904885"
+local IMG_GAMEPASSES = "rbxassetid://137846629770171"
+local IMG_CASH       = "rbxassetid://84262748186110"
+
+--// Player & Gui
+local player  = Players.LocalPlayer
+local pg      = player:WaitForChild("PlayerGui")
+
+--// Utility: springy tween helper
+local function t(obj, ti, props)
+	return TweenService:Create(obj, ti, props)
+end
+
+--// Utility: clamp
+local function clamp(v, a, b)
+	if v < a then return a elseif v > b then return b else return v end
+end
+
+--// Utility: map screen point to GuiObject local space
+local function screenToLocal(guiObject: GuiObject, screenPos: Vector2): Vector2
+	local absPos = guiObject.AbsolutePosition
+	return Vector2.new(screenPos.X - absPos.X, screenPos.Y - absPos.Y)
+end
+
+--// Pill hit test: rounded rectangle with radius = height/2
+local function pointInPill(localPoint: Vector2, width: number, height: number): boolean
+	if width <= 0 or height <= 0 then return false end
+	local r = height * 0.5
+	local x, y = localPoint.X, localPoint.Y
+
+	-- Quick reject outside bounding rect
+	if x < 0 or y < 0 or x > width or y > height then
+		return false
+	end
+
+	-- Central rect (excluding rounded ends)
+	if x >= r and x <= (width - r) then
+		return true
+	end
+
+	-- Left circle center at (r, r)
+	local dxL = x - r
+	local dyL = y - r
+	if (dxL * dxL + dyL * dyL) <= (r * r) then
+		return true
+	end
+
+	-- Right circle center at (width - r, r)
+	local dxR = x - (width - r)
+	local dyR = y - r
+	if (dxR * dxR + dyR * dyR) <= (r * r) then
+		return true
+	end
+
+	return false
+end
+
+--// Strong press/click feedback (no glow)
+local function attachTactile(btn: ImageButton)
+	local baseW, baseH = btn.Size.X.Offset, btn.Size.Y.Offset
+	local hoverW, hoverH = math.floor(baseW * 1.02), math.floor(baseH * 1.02)
+	local downW,  downH  = math.floor(baseW * 0.98), math.floor(baseH * 0.98)
+
+	btn.MouseEnter:Connect(function()
+		t(btn, TweenInfo.new(0.11, Enum.EasingStyle.Quad, Enum.EasingDirection.Out), {
+			Size = UDim2.fromOffset(hoverW, hoverH),
+			ImageTransparency = 0.02
+		}):Play()
+	end)
+
+	local function resetUp()
+		t(btn, TweenInfo.new(0.10, Enum.EasingStyle.Quad, Enum.EasingDirection.Out), {
+			Size = UDim2.fromOffset(hoverW, hoverH),
+			ImageTransparency = 0.00
+		}):Play()
+	end
+
+	btn.MouseLeave:Connect(function()
+		t(btn, TweenInfo.new(0.11, Enum.EasingStyle.Quad, Enum.EasingDirection.Out), {
+			Size = UDim2.fromOffset(baseW, baseH),
+			ImageTransparency = 0.00
+		}):Play()
+	end)
+
+	btn.MouseButton1Down:Connect(function()
+		t(btn, TweenInfo.new(0.06, Enum.EasingStyle.Quad, Enum.EasingDirection.Out), {
+			Size = UDim2.fromOffset(downW, downH)
+		}):Play()
+	end)
+
+	btn.MouseButton1Up:Connect(function()
+		resetUp()
+	end)
+
+	-- For touch devices, emulate hover scale when pressed
+	btn.TouchLongPress:Connect(function(_, state)
+		if state == Enum.UserInputState.Begin then
+			t(btn, TweenInfo.new(0.10, Enum.EasingStyle.Quad, Enum.EasingDirection.Out), {
+				Size = UDim2.fromOffset(hoverW, hoverH)
+			}):Play()
+		end
+	end)
+end
+
+--// Safe container
+local gui = Instance.new("ScreenGui")
+gui.Name = "SanrioShop"
+gui.ResetOnSpawn = false
+gui.IgnoreGuiInset = true
+gui.ZIndexBehavior = Enum.ZIndexBehavior.Sibling
+gui.Enabled = true
+gui.Parent = pg
+
+local root = Instance.new("Frame")
+root.Name = "Root"
+root.BackgroundTransparency = 1
+root.AnchorPoint = Vector2.new(0.5, 0.5)
+root.Position = UDim2.fromScale(0.5, 0.5)
+root.Size = UDim2.fromScale(0.94, 0.94)
+root.Parent = gui
+
+local pad = Instance.new("UIPadding")
+local inset = GuiService:GetGuiInset()
+pad.PaddingTop    = UDim.new(0, inset.Y)
+pad.PaddingBottom = UDim.new(0, 8)
+pad.PaddingLeft   = UDim.new(0, 8)
+pad.PaddingRight  = UDim.new(0, 8)
+pad.Parent = root
+
+--// Main frame (1024x1024) kept square by aspect
+local frame = Instance.new("ImageLabel")
+frame.Name = "ShopFrame"
+frame.BackgroundTransparency = 1
+frame.Image = IMG_FRAME
+frame.ScaleType = Enum.ScaleType.Fit
+frame.AnchorPoint = Vector2.new(0.5, 0.5)
+frame.Position = UDim2.fromScale(0.5, 0.5)
+frame.Size = UDim2.fromScale(1, 1)
+frame.Parent = root
+
+local aspect = Instance.new("UIAspectRatioConstraint")
+aspect.AspectRatio = 1
+aspect.Parent = frame
+
+--// Tabs region (properly sized now!)
+local tabs = Instance.new("Frame")
+tabs.Name = "Tabs"
+tabs.BackgroundTransparency = 1
+tabs.AnchorPoint = Vector2.new(0.5, 0)
+tabs.Position = UDim2.fromScale(0.5, 0.28) -- positioned under SHOP header
+tabs.Size = UDim2.fromScale(0.75, 0)       -- width as scale, height set in resize()
+tabs.Parent = frame
+
+local list = Instance.new("UIListLayout")
+list.FillDirection = Enum.FillDirection.Horizontal
+list.HorizontalAlignment = Enum.HorizontalAlignment.Center
+list.VerticalAlignment = Enum.VerticalAlignment.Center
+list.Padding = UDim.new(0, 16) -- spacing between buttons
+list.Parent = tabs
+
+--// Content area (real pages)
+local content = Instance.new("Frame")
+content.Name = "Content"
+content.BackgroundTransparency = 1
+content.AnchorPoint = Vector2.new(0.5, 0)
+content.Position = UDim2.fromScale(0.5, 0.44) -- positioned below tabs
+content.Size = UDim2.fromScale(0.86, 0.48) -- adjusted for better fit
+content.Parent = frame
+
+local panel = Instance.new("Frame")
+panel.Name = "Panel"
+panel.BackgroundColor3 = Color3.fromRGB(255, 255, 255)
+panel.BackgroundTransparency = 0.9
+panel.Size = UDim2.fromScale(1, 1)
+panel.ClipsDescendants = true
+panel.Parent = content
+local panelCorner = Instance.new("UICorner")
+panelCorner.CornerRadius = UDim.new(0, 18)
+panelCorner.Parent = panel
+
+local pages = Instance.new("Folder")
+pages.Name = "Pages"
+pages.Parent = content
+
+--// Create pill image button with controlled hit test
+local function createPillButton(name: string, imageId: string): ImageButton
+	local btn = Instance.new("ImageButton")
+	btn.Name = name .. "Pill"
+	btn.BackgroundTransparency = 1
+	btn.AutoButtonColor = false
+	btn.Image = imageId
+	btn.ScaleType = Enum.ScaleType.Stretch  -- Fills the button
+	btn.Size = UDim2.fromOffset(200, 60)   -- placeholder, resized later
+	btn.ZIndex = 10
+	btn.Parent = tabs
+
+	-- Attach tactile feedback
+	attachTactile(btn)
+
+	-- Strict pill hit test (no transparent-click cheating)
+	local pressing = false
+	local insideWhenPressed = false
+
+	local function hitTestPointer(pointerPos: Vector2): boolean
+		local lp = screenToLocal(btn, pointerPos)
+		local w, h = btn.AbsoluteSize.X, btn.AbsoluteSize.Y
+		return pointInPill(lp, w, h)
+	end
+
+	-- Intercept normal Activated; we'll manually emit
+	btn.Activated:Connect(function()
+		-- Swallow; our custom path fires handlers instead.
+	end)
+
+	-- Mouse/Touch pathways
+	btn.InputBegan:Connect(function(input: InputObject)
+		if input.UserInputType == Enum.UserInputType.MouseButton1
+			or input.UserInputType == Enum.UserInputType.Touch
+		then
+			pressing = true
+			insideWhenPressed = hitTestPointer(input.Position)
+		end
+	end)
+
+	btn.InputChanged:Connect(function(input: InputObject)
+		if not pressing then return end
+		if input.UserInputType == Enum.UserInputType.MouseMovement
+			or input.UserInputType == Enum.UserInputType.Touch
+			or input.UserInputType == Enum.UserInputType.MouseButton1
+		then
+			-- (Optional: live hover/press visuals based on inside/outside)
+		end
+	end)
+
+	btn.InputEnded:Connect(function(input: InputObject)
+		if not pressing then return end
+		if input.UserInputType == Enum.UserInputType.MouseButton1
+			or input.UserInputType == Enum.UserInputType.Touch
+		then
+			pressing = false
+			local endedInside = hitTestPointer(input.Position)
+			if insideWhenPressed and endedInside then
+				-- Fire a custom signal (BindableEvent per-button)
+				local ev = btn:FindFirstChild("Pressed")
+				if not ev then
+					ev = Instance.new("BindableEvent")
+					ev.Name = "Pressed"
+					ev.Parent = btn
+				end
+				ev:Fire()
+			end
+		end
+	end)
+
+	return btn
+end
+
+--// Sections (pages) factory
+local function createSection(name: string): Frame
+	local page = Instance.new("Frame")
+	page.Name = name
+	page.BackgroundTransparency = 1
+	page.Size = UDim2.fromScale(1,1)
+	page.Visible = false
+	page.Parent = pages
+
+	local scroll = Instance.new("ScrollingFrame")
+	scroll.Name = "Scroll"
+	scroll.BackgroundTransparency = 1
+	scroll.Size = UDim2.fromScale(1,1)
+	scroll.CanvasSize = UDim2.new()
+	scroll.ScrollBarThickness = 6
+	scroll.ScrollingDirection = Enum.ScrollingDirection.Y
+	scroll.Parent = page
+
+	local grid = Instance.new("UIGridLayout")
+	grid.FillDirectionMaxCells = 2
+	grid.CellPadding = UDim2.fromOffset(12, 12)
+	grid.CellSize = UDim2.new(0.49, 0, 0, 110)
+	grid.HorizontalAlignment = Enum.HorizontalAlignment.Center
+	grid.SortOrder = Enum.SortOrder.LayoutOrder
+	grid.Parent = scroll
+
+	return page
+end
+
+--// Instantiate tabs and pages
+local cashTab = createPillButton("Cash", IMG_CASH)
+local gpTab   = createPillButton("Gamepasses", IMG_GAMEPASSES)
+
+local cashPage = createSection("Cash")
+local gpPage   = createSection("Gamepasses")
+
+--// Demo population (replace with real SKUs)
+local function newCard(title: string): TextButton
+	local card = Instance.new("TextButton")
+	card.AutoButtonColor = false
+	card.Text = title
+	card.Font = Enum.Font.GothamBold
+	card.TextScaled = true
+	card.TextColor3 = Color3.fromRGB(75, 60, 120)
+	card.BackgroundColor3 = Color3.fromRGB(255,255,255)
+	card.BackgroundTransparency = 0.86
+	card.Size = UDim2.fromScale(1, 0)
+	card.AutomaticSize = Enum.AutomaticSize.Y
+
+	local c = Instance.new("UICorner")
+	c.CornerRadius = UDim.new(0, 16)
+	c.Parent = card
+
+	-- sample tap feedback
+	card.MouseButton1Click:Connect(function()
+		t(card, TweenInfo.new(0.08, Enum.EasingStyle.Quad, Enum.EasingDirection.Out), {BackgroundTransparency = 0.80}):Play()
+		task.delay(0.10, function()
+			t(card, TweenInfo.new(0.12, Enum.EasingStyle.Quad, Enum.EasingDirection.Out), {BackgroundTransparency = 0.86}):Play()
+		end)
+	end)
+
+	return card
+end
+
+local function populateCash(parentPage: Frame)
+	local scroll = parentPage:FindFirstChild("Scroll") :: ScrollingFrame
+	for i = 1, 8 do
+		newCard(("Cash Pack %d"):format(i)).Parent = scroll
+	end
+end
+
+local function populateGamepasses(parentPage: Frame)
+	local scroll = parentPage:FindFirstChild("Scroll") :: ScrollingFrame
+	local names = {"Auto-Collect", "2x Cash", "Faster Drops", "Cute Boombox", "Cloud Ride", "VIP Badge"}
+	for i, n in ipairs(names) do
+		newCard(("Pass: %s"):format(n)).Parent = scroll
+	end
+end
+
+populateCash(cashPage)
+populateGamepasses(gpPage)
+
+--// Toggle logic
+local function show(which: "cash" | "gp")
+	cashPage.Visible = (which == "cash")
+	gpPage.Visible   = (which == "gp")
+
+	-- tiny slide-in animation for the active page
+	local active = (which == "cash") and cashPage or gpPage
+	active.Position = UDim2.fromScale(1.02, 0)
+	active.Visible = true
+	t(active, TweenInfo.new(0.16, Enum.EasingStyle.Quad, Enum.EasingDirection.Out), {Position = UDim2.fromScale(0, 0)}):Play()
+end
+
+-- default
+show("cash")
+
+-- Precise press handlers (only fire when pill test passes)
+local function onCashTabPressed()
+	print("💰 Cash tab pressed!")
+	show("cash")
+end
+
+local function onGamepassesTabPressed()
+	print("🎫 Gamepasses tab pressed!")
+	show("gp")
+end
+
+-- Wire our custom Pressed events
+do
+	local evC = cashTab:FindFirstChild("Pressed") or Instance.new("BindableEvent")
+	evC.Name = "Pressed"; evC.Parent = cashTab
+	evC.Event:Connect(onCashTabPressed)
+
+	local evG = gpTab:FindFirstChild("Pressed") or Instance.new("BindableEvent")
+	evG.Name = "Pressed"; evG.Parent = gpTab
+	evG.Event:Connect(onGamepassesTabPressed)
+end
+
+--// ✅ FIXED RESIZE LOGIC - PROPER BUTTON SIZING!
+local function resizeSafe()
+	local H = frame.AbsoluteSize.Y
+	if H <= 0 then return end
+
+	-- ✅ FIXED: Reduced from 14% to 8% of frame height
+	local tabPx = clamp(math.floor(H * 0.08), 60, 90)  -- Much smaller!
+	local pillRatio = 3.5  -- width = height * 3.5 (slightly adjusted)
+	local tabW = math.floor(tabPx * pillRatio)
+
+	-- ✅ FIXED: Tabs container now properly sized
+	-- Height is the button height, width scales with frame width (not height!)
+	tabs.Size = UDim2.new(0.75, 0, 0, tabPx)
+	
+	-- Set button sizes
+	cashTab.Size = UDim2.fromOffset(tabW, tabPx)
+	gpTab.Size   = UDim2.fromOffset(tabW, tabPx)
+
+	-- Content panel proportional to frame
+	local contentH = math.floor(H * 0.48)
+	content.Size = UDim2.new(0.86, 0, 0, contentH)
+end
+
+-- Connect resize to frame changes and heartbeat
+frame:GetPropertyChangedSignal("AbsoluteSize"):Connect(resizeSafe)
+RunService.Heartbeat:Connect(function() resizeSafe() end)
+resizeSafe()
+
+print("✅ [SanrioShop] FIXED - Button sizing now correct!")
+
+--------------------------------------------------------------------------------
+-- OPTIONAL: expose a simple toggle API for other scripts
+--------------------------------------------------------------------------------
+local RemotesFolder = ReplicatedStorage:FindFirstChild("TycoonRemotes") or Instance.new("Folder")
+RemotesFolder.Name = "TycoonRemotes"
+RemotesFolder.Parent = ReplicatedStorage
+
+local ToggleShopEvent = RemotesFolder:FindFirstChild("ToggleShopEvent") or Instance.new("BindableEvent")
+ToggleShopEvent.Name = "ToggleShopEvent"
+ToggleShopEvent.Parent = RemotesFolder
+
+ToggleShopEvent.Event:Connect(function(open)
+	gui.Enabled = (open ~= false)
+end)
+
+--------------------------------------------------------------------------------
+-- END
+--------------------------------------------------------------------------------

--- a/SanrioShop_Perfect.lua
+++ b/SanrioShop_Perfect.lua
@@ -409,54 +409,61 @@ function Shop:createProductItem(product, productType, parent)
 	-- Container with YOUR CUSTOM CARD BACKGROUND!
 	local container = Instance.new("ImageLabel")
 	container.Name = product.name .. "Item"
-	container.Size = UDim2.new(1, 0, 0, 48)
+	container.Size = UDim2.new(1, 0, 0, 52)
 	container.BackgroundTransparency = 1
 	container.Image = "rbxassetid://108251319294182"
-	container.ScaleType = Enum.ScaleType.Stretch
+	container.ScaleType = Enum.ScaleType.Crop
 	container.ImageColor3 = Color3.new(1, 1, 1)
 	container.LayoutOrder = product.LayoutOrder or 1
 	container.Parent = parent
 
+	-- Inner content frame for padding
+	local content = Instance.new("Frame")
+	content.Size = UDim2.new(1, -20, 1, -8)
+	content.Position = UDim2.fromOffset(10, 4)
+	content.BackgroundTransparency = 1
+	content.Parent = container
+
 	-- Name on the left
 	local nameLabel = Instance.new("TextLabel")
-	nameLabel.Size = UDim2.new(0.5, -10, 0, 20)
-	nameLabel.Position = UDim2.fromOffset(8, 4)
+	nameLabel.Size = UDim2.new(0.55, 0, 0, 18)
+	nameLabel.Position = UDim2.fromOffset(0, 4)
 	nameLabel.BackgroundTransparency = 1
 	nameLabel.Text = product.name
 	nameLabel.TextColor3 = theme.text
 	nameLabel.Font = Enum.Font.GothamBold
-	nameLabel.TextSize = 16
+	nameLabel.TextSize = 15
 	nameLabel.TextXAlignment = Enum.TextXAlignment.Left
 	nameLabel.TextTruncate = Enum.TextTruncate.AtEnd
-	nameLabel.Parent = container
+	nameLabel.Parent = content
 
 	-- Amount/description below name
 	local descText = isGamepass and product.description or (formatNumber(product.amount))
 	local descLabel = Instance.new("TextLabel")
-	descLabel.Size = UDim2.new(0.5, -10, 0, 16)
-	descLabel.Position = UDim2.fromOffset(8, 26)
+	descLabel.Size = UDim2.new(0.55, 0, 0, 14)
+	descLabel.Position = UDim2.fromOffset(0, 24)
 	descLabel.BackgroundTransparency = 1
 	descLabel.Text = descText
 	descLabel.TextColor3 = theme.textSecondary
 	descLabel.Font = Enum.Font.Gotham
-	descLabel.TextSize = 12
+	descLabel.TextSize = 11
 	descLabel.TextXAlignment = Enum.TextXAlignment.Left
 	descLabel.TextTruncate = Enum.TextTruncate.AtEnd
-	descLabel.Parent = container
+	descLabel.Parent = content
 
 	-- Buy button - clean and flat
 	local buyBtn = Instance.new("TextButton")
-	buyBtn.Size = UDim2.fromOffset(90, 38)
-	buyBtn.Position = UDim2.new(1, -98, 0.5, 0)
+	buyBtn.Size = UDim2.fromOffset(90, 36)
+	buyBtn.Position = UDim2.new(1, -94, 0.5, 0)
 	buyBtn.AnchorPoint = Vector2.new(0, 0.5)
 	buyBtn.BackgroundColor3 = accentColor
 	buyBtn.Text = "R$" .. tostring(product.price or 0)
 	buyBtn.TextColor3 = Color3.new(1, 1, 1)
 	buyBtn.Font = Enum.Font.GothamBold
-	buyBtn.TextSize = 15
+	buyBtn.TextSize = 14
 	buyBtn.AutoButtonColor = false
 	buyBtn.BorderSizePixel = 0
-	buyBtn.Parent = container
+	buyBtn.Parent = content
 	local btnCorner = Instance.new("UICorner"); btnCorner.CornerRadius = UDim.new(0, 8); btnCorner.Parent = buyBtn
 
 	-- Hover effect on button
@@ -474,8 +481,8 @@ function Shop:createProductItem(product, productType, parent)
 
 	-- Toggle for Auto Collect
 	if isGamepass and product.hasToggle and owned then
-		buyBtn.Size = UDim2.fromOffset(70, 38)
-		buyBtn.Position = UDim2.new(1, -78, 0.5, 0)
+		buyBtn.Size = UDim2.fromOffset(70, 36)
+		buyBtn.Position = UDim2.new(1, -74, 0.5, 0)
 		buyBtn.Text = "OFF"
 		local state = false
 		if Remotes then

--- a/SanrioShop_Perfect.lua
+++ b/SanrioShop_Perfect.lua
@@ -401,12 +401,12 @@ function Shop:createProductItem(product, productType, parent)
 	container.LayoutOrder = product.LayoutOrder or 1
 	container.Parent = parent
 
-	-- Visible card background (slightly smaller to avoid crop)
+	-- Visible card background (smaller to prevent crop)
 	local bg = Instance.new("ImageLabel")
 	bg.Name = "CardBG"
 	bg.AnchorPoint = Vector2.new(0.5, 0.5)
 	bg.Position = UDim2.fromScale(0.5, 0.5)
-	bg.Size = UDim2.new(0.94, 0, 0.84, 0)  -- Shrink to prevent top/bottom crop
+	bg.Size = UDim2.new(0.90, 0, 0.76, 0)  -- Much smaller to prevent crop
 	bg.BackgroundTransparency = 1
 	bg.Image = "rbxassetid://108251319294182"
 	bg.ScaleType = Enum.ScaleType.Crop

--- a/SanrioShop_Perfect.lua
+++ b/SanrioShop_Perfect.lua
@@ -54,6 +54,10 @@ local PILL_MAX_H = 120
 local CASH_RATIO = 2.85
 local GP_RATIO = 3.60
 
+-- Card background tuning (ADJUST THESE TO FIT YOUR CARD ART!)
+local CARD_WIDTH = 0.86   -- % of grid cell width the card uses (smaller = less crop)
+local CARD_ASPECT = 3.60  -- width/height ratio of your card art (adjust to match your texture)
+
 -- ======== UTILITIES ========
 local function isMobile() return UserInputService.TouchEnabled and not GuiService:IsTenFootInterface() end
 local function isPhone() if not isMobile() then return false end; local cam=workspace.CurrentCamera; local v=cam.ViewportSize; return math.min(v.X,v.Y)<700 end

--- a/SanrioShop_Perfect.lua
+++ b/SanrioShop_Perfect.lua
@@ -1,8 +1,9 @@
 --[[
-    SANRIO SHOP — PERFECT MERGE
+    SANRIO SHOP — PERFECT MERGE (CARD BACKGROUNDS FIXED)
     ✅ Beautiful pill buttons (from first script)
     ✅ Full functionality (from second script)
-    
+    ✅ Card backgrounds now fill the grid cells (no tiny cards)
+
     Features:
     - Clean pill button design with crop images
     - Purchase system with marketplace
@@ -12,7 +13,7 @@
     - Mobile optimization
     - Smart caching
     - BEST VALUE ribbons
---]]
+]]
 
 -- Services
 local Players = game:GetService("Players")
@@ -36,7 +37,7 @@ local IMG_GAMEPASSES = "rbxassetid://137846629770171"
 local IMG_CASH = "rbxassetid://84262748186110"
 local GIFT_BOX_TEXTURE_ID = "130623477775352" -- ← YOUR GIFT BOX
 
--- ======== LAYOUT CONSTANTS (from first script) ========
+-- ======== LAYOUT CONSTANTS ========
 local FRAME_SCALE = 0.8
 local TAB_ROW_Y = 0.36
 local GP_ROW_EXTRA = 0.02
@@ -215,7 +216,6 @@ function Shop:createToggleButton()
 	self.toggleButton.MouseButton1Click:Connect(function() self:toggle() end)
 end
 
--- ✅ PILL BUTTON CREATION (from first script)
 function Shop:makePill(name, imageId, ratio)
 	local container = Instance.new("Frame")
 	container.Name = name .. "Container"
@@ -256,7 +256,6 @@ function Shop:makePill(name, imageId, ratio)
 end
 
 function Shop:createMainInterface()
-	-- Main ScreenGui
 	self.gui = Instance.new("ScreenGui")
 	self.gui.Name = "SanrioShopMain"
 	self.gui.ResetOnSpawn = false
@@ -265,13 +264,11 @@ function Shop:createMainInterface()
 	self.gui.IgnoreGuiInset = true
 	self.gui.Parent = PlayerGui
 
-	-- Blur
 	self.blur = Lighting:FindFirstChild("SanrioShopBlur") or Instance.new("BlurEffect")
 	self.blur.Name = "SanrioShopBlur"
 	self.blur.Size = 0
 	self.blur.Parent = Lighting
 
-	-- Dim background
 	local dim = Instance.new("Frame")
 	dim.Size = UDim2.fromScale(1, 1)
 	dim.BackgroundColor3 = Color3.new(0, 0, 0)
@@ -279,7 +276,6 @@ function Shop:createMainInterface()
 	dim.BorderSizePixel = 0
 	dim.Parent = self.gui
 
-	-- ✅ Main frame with background image (from first script)
 	self.mainFrame = Instance.new("ImageLabel")
 	self.mainFrame.Name = "MainFrame"
 	self.mainFrame.BackgroundTransparency = 1
@@ -295,7 +291,6 @@ function Shop:createMainInterface()
 	aspect.AspectRatio = 1
 	aspect.Parent = self.mainFrame
 
-	-- ✅ Button bar (from first script)
 	self.buttonBar = Instance.new("Frame")
 	self.buttonBar.Name = "ButtonBar"
 	self.buttonBar.BackgroundTransparency = 1
@@ -305,11 +300,9 @@ function Shop:createMainInterface()
 	self.buttonBar.ZIndex = 5
 	self.buttonBar.Parent = self.mainFrame
 
-	-- ✅ Create pill buttons (from first script)
 	self.cashContainer, self.cashBtn = self:makePill("Cash", IMG_CASH, CASH_RATIO)
 	self.gpContainer, self.gpBtn = self:makePill("Gamepasses", IMG_GAMEPASSES, GP_RATIO)
 
-	-- ✅ Content frame (from first script)
 	self.contentFrame = Instance.new("Frame")
 	self.contentFrame.Name = "Content"
 	self.contentFrame.AnchorPoint = Vector2.new(0.5, 0)
@@ -324,19 +317,14 @@ function Shop:createMainInterface()
 	contentCorner.CornerRadius = UDim.new(0, 20)
 	contentCorner.Parent = self.contentFrame
 
-	-- Create pages
 	self:createPages()
-
-	-- ✅ Setup dynamic sizing (from first script)
 	self:setupDynamicSizing()
 
-	-- Wire button clicks
 	self.cashBtn.MouseButton1Click:Connect(function() self:showCash() end)
 	self.gpBtn.MouseButton1Click:Connect(function() self:showGamepasses() end)
 end
 
 function Shop:createPages()
-	-- Cash page
 	self.cashPage = Instance.new("ScrollingFrame")
 	self.cashPage.Name = "CashPage"
 	self.cashPage.BackgroundTransparency = 1
@@ -364,7 +352,6 @@ function Shop:createPages()
 		self:createProductItem(p, "cash", self.cashPage)
 	end
 
-	-- Gamepasses page
 	self.gpPage = Instance.new("ScrollingFrame")
 	self.gpPage.Name = "GamepassPage"
 	self.gpPage.BackgroundTransparency = 1
@@ -375,8 +362,7 @@ function Shop:createPages()
 	self.gpPage.Size = UDim2.fromScale(1, 1)
 	self.gpPage.ZIndex = 4
 	self.gpPage.Parent = self.contentFrame
-	
-	-- Add padding
+
 	local gpPad = Instance.new("UIPadding")
 	gpPad.PaddingTop = UDim.new(0, 8)
 	gpPad.PaddingBottom = UDim.new(0, 8)
@@ -406,25 +392,23 @@ function Shop:createProductItem(product, productType, parent)
 	local accentColor = isGamepass and theme.kuromi or theme.cinna
 	local owned = isGamepass and checkOwnership(product.id)
 
-	-- Container with YOUR CUSTOM CARD BACKGROUND!
+	-- Card fills entire grid cell with your custom background
 	local container = Instance.new("ImageLabel")
 	container.Name = product.name .. "Item"
-	container.Size = UDim2.new(1, 0, 0, 68)
+	container.Size = UDim2.new(1, 0, 1, 0)
 	container.BackgroundTransparency = 1
 	container.Image = "rbxassetid://108251319294182"
-	container.ScaleType = Enum.ScaleType.Fit
+	container.ScaleType = Enum.ScaleType.Crop
 	container.ImageColor3 = Color3.new(1, 1, 1)
 	container.LayoutOrder = product.LayoutOrder or 1
 	container.Parent = parent
 
-	-- Inner content frame for padding
 	local content = Instance.new("Frame")
 	content.Size = UDim2.new(1, -24, 1, -12)
 	content.Position = UDim2.fromOffset(12, 6)
 	content.BackgroundTransparency = 1
 	content.Parent = container
 
-	-- Name on the left
 	local nameLabel = Instance.new("TextLabel")
 	nameLabel.Size = UDim2.new(0.55, 0, 0, 20)
 	nameLabel.Position = UDim2.fromOffset(0, 8)
@@ -437,7 +421,6 @@ function Shop:createProductItem(product, productType, parent)
 	nameLabel.TextTruncate = Enum.TextTruncate.AtEnd
 	nameLabel.Parent = content
 
-	-- Amount/description below name
 	local descText = isGamepass and product.description or (formatNumber(product.amount))
 	local descLabel = Instance.new("TextLabel")
 	descLabel.Size = UDim2.new(0.55, 0, 0, 16)
@@ -451,7 +434,6 @@ function Shop:createProductItem(product, productType, parent)
 	descLabel.TextTruncate = Enum.TextTruncate.AtEnd
 	descLabel.Parent = content
 
-	-- Buy button - clean and flat
 	local buyBtn = Instance.new("TextButton")
 	buyBtn.Size = UDim2.fromOffset(95, 40)
 	buyBtn.Position = UDim2.new(1, -98, 0.5, 0)
@@ -466,7 +448,6 @@ function Shop:createProductItem(product, productType, parent)
 	buyBtn.Parent = content
 	local btnCorner = Instance.new("UICorner"); btnCorner.CornerRadius = UDim.new(0, 10); btnCorner.Parent = buyBtn
 
-	-- Hover effect on button
 	buyBtn.MouseEnter:Connect(function()
 		playSound("hover")
 		TweenService:Create(buyBtn,TweenInfo.new(0.12),{BackgroundColor3=blend(accentColor, Color3.new(1,1,1), 0.2)}):Play()
@@ -477,9 +458,6 @@ function Shop:createProductItem(product, productType, parent)
 		end
 	end)
 
-	-- No separator needed with custom card background!
-
-	-- Toggle for Auto Collect
 	if isGamepass and product.hasToggle and owned then
 		buyBtn.Size = UDim2.fromOffset(75, 40)
 		buyBtn.Position = UDim2.new(1, -78, 0.5, 0)
@@ -492,7 +470,7 @@ function Shop:createProductItem(product, productType, parent)
 				if ok and type(val) == "boolean" then state = val end
 			end
 		end
-		
+
 		local function paint(on)
 			state = on
 			if on then
@@ -504,7 +482,7 @@ function Shop:createProductItem(product, productType, parent)
 			end
 		end
 		paint(state)
-		
+
 		buyBtn.MouseButton1Click:Connect(function()
 			local nextState = not state
 			paint(nextState)
@@ -531,9 +509,6 @@ function Shop:createProductItem(product, productType, parent)
 	product.purchaseButton = buyBtn
 end
 
--- Toggle functionality is now integrated into createProductItem
-
--- ✅ DYNAMIC SIZING (from first script)
 function Shop:setupDynamicSizing()
 	local function resize()
 		local H = self.mainFrame.AbsoluteSize.Y
@@ -642,14 +617,12 @@ function Shop:toggle()
 end
 
 function Shop:setupHandlers()
-	-- Input
 	UserInputService.InputBegan:Connect(function(i, gp)
 		if gp then return end
 		if i.KeyCode == Enum.KeyCode.M then self:toggle() end
 		if i.KeyCode == Enum.KeyCode.Escape and self.isOpen then self:close() end
 	end)
 
-	-- Remotes
 	if Remotes then
 		local gpPurchased = Remotes:FindFirstChild("GamepassPurchased")
 		if gpPurchased and gpPurchased:IsA("RemoteEvent") then
@@ -661,7 +634,6 @@ function Shop:setupHandlers()
 		end
 	end
 
-	-- Purchase callbacks
 	MarketplaceService.PromptGamePassPurchaseFinished:Connect(function(player, passId, purchased)
 		if player ~= Player then return end
 		local p = self.purchasePending[passId]
@@ -700,7 +672,6 @@ function Shop:setupHandlers()
 	end)
 end
 
--- ======== BOOT ========
 local shop = Shop.new()
 shop:initialize()
 
@@ -711,6 +682,7 @@ Player.CharacterAdded:Connect(function()
 	end
 end)
 
-print("[SanrioShop] ✨ PERFECT MERGE: Beautiful pills + Full functionality!")
+print("[SanrioShop] ✨ Card backgrounds now fill properly!")
 print("[SanrioShop] 🎁 Gift box texture:", GIFT_BOX_TEXTURE_ID)
+
 return shop

--- a/SanrioShop_Perfect.lua
+++ b/SanrioShop_Perfect.lua
@@ -392,22 +392,33 @@ function Shop:createProductItem(product, productType, parent)
 	local accentColor = isGamepass and theme.kuromi or theme.cinna
 	local owned = isGamepass and checkOwnership(product.id)
 
-	-- Card fills entire grid cell with your custom background
-	local container = Instance.new("ImageLabel")
-	container.Name = product.name .. "Item"
+	-- Cell container (fills the grid cell; no visual)
+	local container = Instance.new("Frame")
+	container.Name = product.name .. "Cell"
 	container.Size = UDim2.new(1, 0, 1, 0)
 	container.BackgroundTransparency = 1
-	container.Image = "rbxassetid://108251319294182"
-	container.ScaleType = Enum.ScaleType.Crop
-	container.ImageColor3 = Color3.new(1, 1, 1)
+	container.BorderSizePixel = 0
 	container.LayoutOrder = product.LayoutOrder or 1
 	container.Parent = parent
 
+	-- Visible card background (slightly smaller to avoid crop)
+	local bg = Instance.new("ImageLabel")
+	bg.Name = "CardBG"
+	bg.AnchorPoint = Vector2.new(0.5, 0.5)
+	bg.Position = UDim2.fromScale(0.5, 0.5)
+	bg.Size = UDim2.new(0.94, 0, 0.84, 0)  -- Shrink to prevent top/bottom crop
+	bg.BackgroundTransparency = 1
+	bg.Image = "rbxassetid://108251319294182"
+	bg.ScaleType = Enum.ScaleType.Crop
+	bg.Parent = container
+
+	-- Inner content (text & button) sits on top of the bg
 	local content = Instance.new("Frame")
+	content.Name = "Content"
 	content.Size = UDim2.new(1, -24, 1, -12)
 	content.Position = UDim2.fromOffset(12, 6)
 	content.BackgroundTransparency = 1
-	content.Parent = container
+	content.Parent = bg
 
 	local nameLabel = Instance.new("TextLabel")
 	nameLabel.Size = UDim2.new(0.55, 0, 0, 20)
@@ -505,7 +516,8 @@ function Shop:createProductItem(product, productType, parent)
 		end)
 	end
 
-	product.cardInstance = container
+	-- Effects target the visible bg
+	product.cardInstance = bg
 	product.purchaseButton = buyBtn
 end
 

--- a/SanrioShop_Perfect.lua
+++ b/SanrioShop_Perfect.lua
@@ -356,7 +356,7 @@ function Shop:createPages()
 	cashGrid.Parent = self.cashPage
 
 	cashGrid:GetPropertyChangedSignal("AbsoluteContentSize"):Connect(function()
-		self.cashPage.CanvasSize = UDim2.new(0, 0, 0, cashGrid.AbsoluteContentSize.Y + 20)
+		self.cashPage.CanvasSize = UDim2.new(0, 0, 0, cashGrid.AbsoluteContentSize.Y + 16)
 	end)
 
 	for _, p in ipairs(products.cash) do
@@ -368,22 +368,30 @@ function Shop:createPages()
 	self.gpPage.Name = "GamepassPage"
 	self.gpPage.BackgroundTransparency = 1
 	self.gpPage.BorderSizePixel = 0
-	self.gpPage.ScrollBarThickness = 6
+	self.gpPage.ScrollBarThickness = 5
 	self.gpPage.ScrollBarImageColor3 = theme.accent
 	self.gpPage.Visible = false
 	self.gpPage.Size = UDim2.fromScale(1, 1)
 	self.gpPage.ZIndex = 4
 	self.gpPage.Parent = self.contentFrame
+	
+	-- Add padding
+	local gpPad = Instance.new("UIPadding")
+	gpPad.PaddingTop = UDim.new(0, 8)
+	gpPad.PaddingBottom = UDim.new(0, 8)
+	gpPad.PaddingLeft = UDim.new(0, 8)
+	gpPad.PaddingRight = UDim.new(0, 8)
+	gpPad.Parent = self.gpPage
 
 	local gpGrid = Instance.new("UIGridLayout")
-	gpGrid.CellSize = UDim2.new(0.48, 0, 0, 110)
-	gpGrid.CellPadding = UDim2.fromOffset(12, 12)
+	gpGrid.CellSize = UDim2.new(0.48, 0, 0, 130)
+	gpGrid.CellPadding = UDim2.fromOffset(10, 10)
 	gpGrid.HorizontalAlignment = Enum.HorizontalAlignment.Center
 	gpGrid.SortOrder = Enum.SortOrder.LayoutOrder
 	gpGrid.Parent = self.gpPage
 
 	gpGrid:GetPropertyChangedSignal("AbsoluteContentSize"):Connect(function()
-		self.gpPage.CanvasSize = UDim2.new(0, 0, 0, gpGrid.AbsoluteContentSize.Y + 20)
+		self.gpPage.CanvasSize = UDim2.new(0, 0, 0, gpGrid.AbsoluteContentSize.Y + 16)
 	end)
 
 	for _, gp in ipairs(products.gamepasses) do
@@ -395,105 +403,128 @@ function Shop:createProductCard(product, productType, parent)
 	local isGamepass = (productType == "gamepass")
 	local cardColor = isGamepass and theme.kuromi or theme.cinna
 
-	local card = Instance.new("Frame")
+	-- Main card container
+	local card = Instance.new("TextButton")
 	card.Name = product.name .. "Card"
-	card.BackgroundColor3 = theme.surface
+	card.BackgroundColor3 = cardColor
 	card.BorderSizePixel = 0
-	card.ClipsDescendants = true
+	card.AutoButtonColor = false
+	card.Text = ""
+	card.ClipsDescendants = false
 	card.Parent = parent
 
-	local corner = Instance.new("UICorner"); corner.CornerRadius = UDim.new(0, 14); corner.Parent = card
-	local stroke = Instance.new("UIStroke"); stroke.Color = cardColor; stroke.Thickness = 2; stroke.Transparency = 0.45; stroke.Parent = card
+	local corner = Instance.new("UICorner"); corner.CornerRadius = UDim.new(0, 12); corner.Parent = card
 
+	-- Hover effect
 	local hoverScale = Instance.new("UIScale"); hoverScale.Scale = 1; hoverScale.Parent = card
-	card.MouseEnter:Connect(function() playSound("hover"); TweenService:Create(hoverScale,TweenInfo.new(0.15),{Scale=1.03}):Play() end)
-	card.MouseLeave:Connect(function() TweenService:Create(hoverScale,TweenInfo.new(0.15),{Scale=1}):Play() end)
+	card.MouseEnter:Connect(function() 
+		playSound("hover")
+		TweenService:Create(hoverScale,TweenInfo.new(0.12),{Scale=1.04}):Play() 
+	end)
+	card.MouseLeave:Connect(function() 
+		TweenService:Create(hoverScale,TweenInfo.new(0.12),{Scale=1}):Play() 
+	end)
 
-	-- Image area
-	local imgContainer = Instance.new("Frame")
-	imgContainer.Size = UDim2.new(1, 0, 0, 50)
-	imgContainer.Position = UDim2.fromOffset(0, 4)
-	imgContainer.BackgroundColor3 = theme.surfaceAlt
-	imgContainer.BorderSizePixel = 0
-	imgContainer.Parent = card
-	local imgCorner = Instance.new("UICorner"); imgCorner.CornerRadius = UDim.new(0, 10); imgCorner.Parent = imgContainer
+	-- Inner content with padding
+	local content = Instance.new("Frame")
+	content.Size = UDim2.new(1, -8, 1, -8)
+	content.Position = UDim2.fromOffset(4, 4)
+	content.BackgroundColor3 = theme.surface
+	content.BorderSizePixel = 0
+	content.Parent = card
+	local contentCorner = Instance.new("UICorner"); contentCorner.CornerRadius = UDim.new(0, 10); contentCorner.Parent = content
 
-	local img = Instance.new("ImageLabel")
-	img.Image = product.icon or "rbxassetid://0"
-	img.Size = UDim2.fromScale(0.6, 0.6)
-	img.Position = UDim2.fromScale(0.5, 0.5)
-	img.AnchorPoint = Vector2.new(0.5, 0.5)
-	img.BackgroundTransparency = 1
-	img.Parent = imgContainer
-
-	-- BEST VALUE ribbon
+	-- BEST VALUE corner badge
 	if not isGamepass and product.best then
-		local ribbon = Instance.new("TextLabel")
-		ribbon.BackgroundColor3 = theme.accent
-		ribbon.Text = "BEST"
-		ribbon.TextColor3 = Color3.new(1,1,1)
-		ribbon.Font = Enum.Font.GothamBold
-		ribbon.TextSize = 10
-		ribbon.Size = UDim2.fromOffset(38, 16)
-		ribbon.Position = UDim2.fromOffset(4, 4)
-		ribbon.Parent = imgContainer
-		local c = Instance.new("UICorner"); c.CornerRadius = UDim.new(0, 6); c.Parent = ribbon
+		local badge = Instance.new("TextLabel")
+		badge.BackgroundColor3 = theme.accent
+		badge.Text = "BEST"
+		badge.TextColor3 = Color3.new(1,1,1)
+		badge.Font = Enum.Font.GothamBold
+		badge.TextSize = 9
+		badge.Size = UDim2.fromOffset(34, 14)
+		badge.Position = UDim2.fromOffset(4, 4)
+		badge.Parent = content
+		local bc = Instance.new("UICorner"); bc.CornerRadius = UDim.new(0, 4); bc.Parent = badge
 	end
 
-	-- Title
-	local title = Instance.new("TextLabel")
-	title.Size = UDim2.new(1, -12, 0, 18)
-	title.Position = UDim2.fromOffset(6, 58)
-	title.BackgroundTransparency = 1
-	title.Text = product.name
-	title.TextColor3 = theme.text
-	title.Font = Enum.Font.GothamBold
-	title.TextSize = 14
-	title.TextXAlignment = Enum.TextXAlignment.Left
-	title.TextTruncate = Enum.TextTruncate.AtEnd
-	title.Parent = card
+	-- Product icon
+	local icon = Instance.new("ImageLabel")
+	icon.Image = product.icon or "rbxassetid://0"
+	icon.Size = UDim2.fromOffset(32, 32)
+	icon.Position = UDim2.fromScale(0.5, 0)
+	icon.AnchorPoint = Vector2.new(0.5, 0)
+	icon.Position = UDim2.new(0.5, 0, 0, 8)
+	icon.BackgroundTransparency = 1
+	icon.Parent = content
 
-	-- Description
-	local desc = Instance.new("TextLabel")
-	desc.Size = UDim2.new(1, -12, 0, 16)
-	desc.Position = UDim2.fromOffset(6, 78)
-	desc.BackgroundTransparency = 1
-	desc.Text = isGamepass and product.description or (formatNumber(product.amount) .. " Cash")
-	desc.TextColor3 = theme.textSecondary
-	desc.Font = Enum.Font.Gotham
-	desc.TextSize = 11
-	desc.TextXAlignment = Enum.TextXAlignment.Left
-	desc.TextTruncate = Enum.TextTruncate.AtEnd
-	desc.Parent = card
+	-- Product name
+	local nameLabel = Instance.new("TextLabel")
+	nameLabel.Size = UDim2.new(1, -8, 0, 16)
+	nameLabel.Position = UDim2.fromOffset(4, 46)
+	nameLabel.BackgroundTransparency = 1
+	nameLabel.Text = product.name
+	nameLabel.TextColor3 = theme.text
+	nameLabel.Font = Enum.Font.GothamBold
+	nameLabel.TextSize = 13
+	nameLabel.TextXAlignment = Enum.TextXAlignment.Center
+	nameLabel.TextTruncate = Enum.TextTruncate.AtEnd
+	nameLabel.Parent = content
 
-	-- Bonus label
+	-- Amount/Description
+	local descLabel = Instance.new("TextLabel")
+	descLabel.Size = UDim2.new(1, -8, 0, 14)
+	descLabel.Position = UDim2.fromOffset(4, 64)
+	descLabel.BackgroundTransparency = 1
+	descLabel.Text = isGamepass and product.description or (formatNumber(product.amount))
+	descLabel.TextColor3 = theme.textSecondary
+	descLabel.Font = Enum.Font.Gotham
+	descLabel.TextSize = 10
+	descLabel.TextXAlignment = Enum.TextXAlignment.Center
+	descLabel.TextWrapped = true
+	descLabel.Parent = content
+
+	-- Bonus (if exists)
 	if not isGamepass and product.bonus and product.bonus > 0 then
-		local bonus = Instance.new("TextLabel")
-		bonus.Size = UDim2.new(1, -12, 0, 14)
-		bonus.Position = UDim2.fromOffset(6, 94)
-		bonus.BackgroundTransparency = 1
-		bonus.Text = formatBonusText(product.bonus)
-		bonus.TextColor3 = theme.accent
-		bonus.Font = Enum.Font.Gotham
-		bonus.TextSize = 10
-		bonus.TextXAlignment = Enum.TextXAlignment.Left
-		bonus.Parent = card
+		local bonusLabel = Instance.new("TextLabel")
+		bonusLabel.Size = UDim2.new(1, -8, 0, 12)
+		bonusLabel.Position = UDim2.fromOffset(4, 80)
+		bonusLabel.BackgroundTransparency = 1
+		bonusLabel.Text = formatBonusText(product.bonus)
+		bonusLabel.TextColor3 = theme.accent
+		bonusLabel.Font = Enum.Font.GothamBold
+		bonusLabel.TextSize = 9
+		bonusLabel.TextXAlignment = Enum.TextXAlignment.Center
+		bonusLabel.Parent = content
 	end
 
 	-- Buy button
 	local owned = isGamepass and checkOwnership(product.id)
 	local buyBtn = Instance.new("TextButton")
-	buyBtn.Size = UDim2.new(1, -12, 0, 26)
-	buyBtn.Position = UDim2.new(0, 6, 1, -30)
-	buyBtn.BackgroundColor3 = owned and theme.success or cardColor
-	buyBtn.Text = owned and "✓ Owned" or ("R$" .. tostring(product.price or 0))
+	buyBtn.Size = UDim2.new(1, -12, 0, 24)
+	buyBtn.Position = UDim2.new(0.5, 0, 1, -28)
+	buyBtn.AnchorPoint = Vector2.new(0.5, 0)
+	buyBtn.BackgroundColor3 = owned and theme.success or theme.accent
+	buyBtn.Text = owned and "✓ OWNED" or ("R$" .. tostring(product.price or 0))
 	buyBtn.TextColor3 = Color3.new(1, 1, 1)
 	buyBtn.Font = Enum.Font.GothamBold
-	buyBtn.TextSize = 13
+	buyBtn.TextSize = 12
 	buyBtn.AutoButtonColor = false
 	buyBtn.Active = not owned
-	buyBtn.Parent = card
+	buyBtn.Parent = content
 	local btnCorner = Instance.new("UICorner"); btnCorner.CornerRadius = UDim.new(0, 8); btnCorner.Parent = buyBtn
+
+	-- Button press effect
+	buyBtn.MouseButton1Down:Connect(function()
+		if not owned then
+			TweenService:Create(buyBtn,TweenInfo.new(0.08),{BackgroundColor3 = blend(buyBtn.BackgroundColor3, Color3.new(0,0,0), 0.15)}):Play()
+		end
+	end)
+	buyBtn.MouseButton1Up:Connect(function()
+		if not owned then
+			TweenService:Create(buyBtn,TweenInfo.new(0.12),{BackgroundColor3 = theme.accent}):Play()
+		end
+	end)
 
 	buyBtn.MouseButton1Click:Connect(function()
 		if owned then return end
@@ -502,9 +533,9 @@ function Shop:createProductCard(product, productType, parent)
 		self:promptPurchase(product, productType, buyBtn)
 	end)
 
-	-- Toggle for Auto Collect
+	-- Toggle for Auto Collect (compact version in corner)
 	if isGamepass and product.hasToggle and owned then
-		self:addToggleSwitch(product, imgContainer)
+		self:addToggleSwitch(product, content)
 	end
 
 	product.cardInstance = card
@@ -512,23 +543,28 @@ function Shop:createProductCard(product, productType, parent)
 end
 
 function Shop:addToggleSwitch(product, parent)
+	-- Compact toggle that replaces the buy button when owned
 	local toggle = Instance.new("Frame")
-	toggle.Size = UDim2.fromOffset(110, 22)
-	toggle.Position = UDim2.new(1, -4, 0, 4)
-	toggle.AnchorPoint = Vector2.new(1, 0)
-	toggle.BackgroundColor3 = theme.surface
+	toggle.Name = "ToggleSwitch"
+	toggle.Size = UDim2.new(1, -12, 0, 24)
+	toggle.Position = UDim2.new(0.5, 0, 1, -28)
+	toggle.AnchorPoint = Vector2.new(0.5, 0)
+	toggle.BackgroundColor3 = theme.stroke
 	toggle.BorderSizePixel = 0
 	toggle.Parent = parent
-	local tc = Instance.new("UICorner"); tc.CornerRadius = UDim.new(0, 11); tc.Parent = toggle
-	local ts = Instance.new("UIStroke"); ts.Color = theme.stroke; ts.Thickness = 1; ts.Parent = toggle
+	local tc = Instance.new("UICorner"); tc.CornerRadius = UDim.new(0, 8); tc.Parent = toggle
+
+	-- Hide the buy button since toggle replaces it
+	local buyBtn = parent:FindFirstChild("TextButton")
+	if buyBtn then buyBtn.Visible = false end
 
 	local label = Instance.new("TextLabel")
 	label.Size = UDim2.fromScale(1, 1)
 	label.BackgroundTransparency = 1
-	label.Text = "Auto: OFF"
+	label.Text = "AUTO: OFF"
 	label.TextColor3 = theme.text
 	label.Font = Enum.Font.GothamBold
-	label.TextSize = 10
+	label.TextSize = 11
 	label.Parent = toggle
 
 	local btn = Instance.new("TextButton")
@@ -550,18 +586,24 @@ function Shop:addToggleSwitch(product, parent)
 		state = on
 		if on then
 			toggle.BackgroundColor3 = theme.success
-			ts.Color = theme.success
 			label.TextColor3 = Color3.new(1, 1, 1)
-			label.Text = "Auto: ON"
+			label.Text = "AUTO: ON ✓"
 		else
-			toggle.BackgroundColor3 = theme.surface
-			ts.Color = theme.stroke
+			toggle.BackgroundColor3 = theme.stroke
 			label.TextColor3 = theme.text
-			label.Text = "Auto: OFF"
+			label.Text = "AUTO: OFF"
 		end
 	end
 
 	paint(state)
+
+	-- Hover effect
+	btn.MouseEnter:Connect(function()
+		TweenService:Create(toggle,TweenInfo.new(0.12),{BackgroundColor3 = blend(toggle.BackgroundColor3, state and Color3.new(1,1,1) or Color3.new(0,0,0), 0.1)}):Play()
+	end)
+	btn.MouseLeave:Connect(function()
+		paint(state)
+	end)
 
 	btn.MouseButton1Click:Connect(function()
 		local nextState = not state

--- a/SanrioShop_Perfect.lua
+++ b/SanrioShop_Perfect.lua
@@ -406,11 +406,14 @@ function Shop:createProductItem(product, productType, parent)
 	local accentColor = isGamepass and theme.kuromi or theme.cinna
 	local owned = isGamepass and checkOwnership(product.id)
 
-	-- Container (NO background, NO borders, NO card look!)
-	local container = Instance.new("Frame")
+	-- Container with YOUR CUSTOM CARD BACKGROUND!
+	local container = Instance.new("ImageLabel")
 	container.Name = product.name .. "Item"
 	container.Size = UDim2.new(1, 0, 0, 48)
 	container.BackgroundTransparency = 1
+	container.Image = "rbxassetid://108251319294182"
+	container.ScaleType = Enum.ScaleType.Stretch
+	container.ImageColor3 = Color3.new(1, 1, 1)
 	container.LayoutOrder = product.LayoutOrder or 1
 	container.Parent = parent
 
@@ -467,14 +470,7 @@ function Shop:createProductItem(product, productType, parent)
 		end
 	end)
 
-	-- Separator line below
-	local line = Instance.new("Frame")
-	line.Size = UDim2.new(1, -16, 0, 1)
-	line.Position = UDim2.new(0, 8, 1, -1)
-	line.BackgroundColor3 = theme.stroke
-	line.BackgroundTransparency = 0.5
-	line.BorderSizePixel = 0
-	line.Parent = container
+	-- No separator needed with custom card background!
 
 	-- Toggle for Auto Collect
 	if isGamepass and product.hasToggle and owned then

--- a/SanrioShop_Perfect.lua
+++ b/SanrioShop_Perfect.lua
@@ -349,8 +349,8 @@ function Shop:createPages()
 	self.cashPage.Parent = self.contentFrame
 
 	local cashGrid = Instance.new("UIGridLayout")
-	cashGrid.CellSize = UDim2.new(0.48, 0, 0, 105)
-	cashGrid.CellPadding = UDim2.fromOffset(12, 12)
+	cashGrid.CellSize = UDim2.new(0.48, 0, 0, 95)
+	cashGrid.CellPadding = UDim2.fromOffset(10, 10)
 	cashGrid.HorizontalAlignment = Enum.HorizontalAlignment.Center
 	cashGrid.SortOrder = Enum.SortOrder.LayoutOrder
 	cashGrid.Parent = self.cashPage
@@ -384,7 +384,7 @@ function Shop:createPages()
 	gpPad.Parent = self.gpPage
 
 	local gpGrid = Instance.new("UIGridLayout")
-	gpGrid.CellSize = UDim2.new(0.48, 0, 0, 105)
+	gpGrid.CellSize = UDim2.new(0.48, 0, 0, 95)
 	gpGrid.CellPadding = UDim2.fromOffset(10, 10)
 	gpGrid.HorizontalAlignment = Enum.HorizontalAlignment.Center
 	gpGrid.SortOrder = Enum.SortOrder.LayoutOrder
@@ -462,23 +462,37 @@ function Shop:createProductCard(product, productType, parent)
 	descLabel.TextWrapped = true
 	descLabel.Parent = textArea
 
-	-- Price/Buy button at bottom
+	-- Show OWNED text if gamepass is owned (above button area)
+	if isGamepass and owned and not product.hasToggle then
+		local ownedLabel = Instance.new("TextLabel")
+		ownedLabel.Size = UDim2.new(1, 0, 0, 16)
+		ownedLabel.Position = UDim2.new(0, 0, 1, -54)
+		ownedLabel.BackgroundTransparency = 1
+		ownedLabel.Text = "✓ OWNED"
+		ownedLabel.TextColor3 = theme.success
+		ownedLabel.Font = Enum.Font.GothamBold
+		ownedLabel.TextSize = 12
+		ownedLabel.TextXAlignment = Enum.TextXAlignment.Center
+		ownedLabel.Parent = card
+	end
+
+	-- Price/Buy button OR Toggle at bottom
 	local buyBtn = Instance.new("TextButton")
 	buyBtn.Size = UDim2.new(1, -16, 0, 28)
 	buyBtn.Position = UDim2.new(0, 8, 1, -36)
-	buyBtn.BackgroundColor3 = owned and theme.success or cardColor
-	buyBtn.Text = owned and "✓ OWNED" or ("💰 R$" .. tostring(product.price or 0))
+	buyBtn.BackgroundColor3 = cardColor
+	buyBtn.Text = "R$" .. tostring(product.price or 0)
 	buyBtn.TextColor3 = Color3.new(1, 1, 1)
 	buyBtn.Font = Enum.Font.GothamBold
 	buyBtn.TextSize = 14
 	buyBtn.AutoButtonColor = false
-	buyBtn.Active = not owned
+	buyBtn.Active = true
 	buyBtn.Parent = card
 	local btnCorner = Instance.new("UICorner"); btnCorner.CornerRadius = UDim.new(0, 10); btnCorner.Parent = buyBtn
 
-	-- Toggle for Auto Collect
+	-- Toggle for Auto Collect (replaces button completely)
 	if isGamepass and product.hasToggle and owned then
-		buyBtn.Text = "AUTO: OFF"
+		buyBtn.Text = "OFF"
 		local state = false
 		if Remotes then
 			local rf = Remotes:FindFirstChild("GetAutoCollectState")
@@ -492,15 +506,26 @@ function Shop:createProductCard(product, productType, parent)
 			state = on
 			if on then
 				buyBtn.BackgroundColor3 = theme.success
-				buyBtn.Text = "AUTO: ON ✓"
+				buyBtn.Text = "ON"
 			else
 				buyBtn.BackgroundColor3 = theme.stroke
-				buyBtn.Text = "AUTO: OFF"
+				buyBtn.Text = "OFF"
 			end
 		end
 		paint(state)
 		
-		buyBtn.Active = true
+		-- Add OWNED label above toggle
+		local ownedLabel = Instance.new("TextLabel")
+		ownedLabel.Size = UDim2.new(1, 0, 0, 14)
+		ownedLabel.Position = UDim2.new(0, 0, 1, -52)
+		ownedLabel.BackgroundTransparency = 1
+		ownedLabel.Text = "✓ OWNED"
+		ownedLabel.TextColor3 = theme.success
+		ownedLabel.Font = Enum.Font.GothamBold
+		ownedLabel.TextSize = 10
+		ownedLabel.TextXAlignment = Enum.TextXAlignment.Center
+		ownedLabel.Parent = card
+		
 		buyBtn.MouseButton1Click:Connect(function()
 			local nextState = not state
 			paint(nextState)
@@ -510,6 +535,11 @@ function Shop:createProductCard(product, productType, parent)
 				if ev and ev:IsA("RemoteEvent") then ev:FireServer(nextState) end
 			end
 		end)
+	elseif isGamepass and owned then
+		-- Non-toggle gamepass that's owned
+		buyBtn.BackgroundColor3 = theme.success
+		buyBtn.Text = "✓ OWNED"
+		buyBtn.Active = false
 	else
 		-- Regular purchase button
 		buyBtn.MouseButton1Click:Connect(function()

--- a/SanrioShop_Perfect.lua
+++ b/SanrioShop_Perfect.lua
@@ -409,30 +409,30 @@ function Shop:createProductItem(product, productType, parent)
 	-- Container with YOUR CUSTOM CARD BACKGROUND!
 	local container = Instance.new("ImageLabel")
 	container.Name = product.name .. "Item"
-	container.Size = UDim2.new(1, 0, 0, 52)
+	container.Size = UDim2.new(1, 0, 0, 68)
 	container.BackgroundTransparency = 1
 	container.Image = "rbxassetid://108251319294182"
-	container.ScaleType = Enum.ScaleType.Crop
+	container.ScaleType = Enum.ScaleType.Fit
 	container.ImageColor3 = Color3.new(1, 1, 1)
 	container.LayoutOrder = product.LayoutOrder or 1
 	container.Parent = parent
 
 	-- Inner content frame for padding
 	local content = Instance.new("Frame")
-	content.Size = UDim2.new(1, -20, 1, -8)
-	content.Position = UDim2.fromOffset(10, 4)
+	content.Size = UDim2.new(1, -24, 1, -12)
+	content.Position = UDim2.fromOffset(12, 6)
 	content.BackgroundTransparency = 1
 	content.Parent = container
 
 	-- Name on the left
 	local nameLabel = Instance.new("TextLabel")
-	nameLabel.Size = UDim2.new(0.55, 0, 0, 18)
-	nameLabel.Position = UDim2.fromOffset(0, 4)
+	nameLabel.Size = UDim2.new(0.55, 0, 0, 20)
+	nameLabel.Position = UDim2.fromOffset(0, 8)
 	nameLabel.BackgroundTransparency = 1
 	nameLabel.Text = product.name
 	nameLabel.TextColor3 = theme.text
 	nameLabel.Font = Enum.Font.GothamBold
-	nameLabel.TextSize = 15
+	nameLabel.TextSize = 16
 	nameLabel.TextXAlignment = Enum.TextXAlignment.Left
 	nameLabel.TextTruncate = Enum.TextTruncate.AtEnd
 	nameLabel.Parent = content
@@ -440,31 +440,31 @@ function Shop:createProductItem(product, productType, parent)
 	-- Amount/description below name
 	local descText = isGamepass and product.description or (formatNumber(product.amount))
 	local descLabel = Instance.new("TextLabel")
-	descLabel.Size = UDim2.new(0.55, 0, 0, 14)
-	descLabel.Position = UDim2.fromOffset(0, 24)
+	descLabel.Size = UDim2.new(0.55, 0, 0, 16)
+	descLabel.Position = UDim2.fromOffset(0, 32)
 	descLabel.BackgroundTransparency = 1
 	descLabel.Text = descText
 	descLabel.TextColor3 = theme.textSecondary
 	descLabel.Font = Enum.Font.Gotham
-	descLabel.TextSize = 11
+	descLabel.TextSize = 12
 	descLabel.TextXAlignment = Enum.TextXAlignment.Left
 	descLabel.TextTruncate = Enum.TextTruncate.AtEnd
 	descLabel.Parent = content
 
 	-- Buy button - clean and flat
 	local buyBtn = Instance.new("TextButton")
-	buyBtn.Size = UDim2.fromOffset(90, 36)
-	buyBtn.Position = UDim2.new(1, -94, 0.5, 0)
+	buyBtn.Size = UDim2.fromOffset(95, 40)
+	buyBtn.Position = UDim2.new(1, -98, 0.5, 0)
 	buyBtn.AnchorPoint = Vector2.new(0, 0.5)
 	buyBtn.BackgroundColor3 = accentColor
 	buyBtn.Text = "R$" .. tostring(product.price or 0)
 	buyBtn.TextColor3 = Color3.new(1, 1, 1)
 	buyBtn.Font = Enum.Font.GothamBold
-	buyBtn.TextSize = 14
+	buyBtn.TextSize = 15
 	buyBtn.AutoButtonColor = false
 	buyBtn.BorderSizePixel = 0
 	buyBtn.Parent = content
-	local btnCorner = Instance.new("UICorner"); btnCorner.CornerRadius = UDim.new(0, 8); btnCorner.Parent = buyBtn
+	local btnCorner = Instance.new("UICorner"); btnCorner.CornerRadius = UDim.new(0, 10); btnCorner.Parent = buyBtn
 
 	-- Hover effect on button
 	buyBtn.MouseEnter:Connect(function()
@@ -481,8 +481,8 @@ function Shop:createProductItem(product, productType, parent)
 
 	-- Toggle for Auto Collect
 	if isGamepass and product.hasToggle and owned then
-		buyBtn.Size = UDim2.fromOffset(70, 36)
-		buyBtn.Position = UDim2.new(1, -74, 0.5, 0)
+		buyBtn.Size = UDim2.fromOffset(75, 40)
+		buyBtn.Position = UDim2.new(1, -78, 0.5, 0)
 		buyBtn.Text = "OFF"
 		local state = false
 		if Remotes then

--- a/SanrioShop_Perfect.lua
+++ b/SanrioShop_Perfect.lua
@@ -406,88 +406,80 @@ function Shop:createProductItem(product, productType, parent)
 	local accentColor = isGamepass and theme.kuromi or theme.cinna
 	local owned = isGamepass and checkOwnership(product.id)
 
-	-- List item row
-	local row = Instance.new("TextButton")
-	row.Name = product.name .. "Row"
-	row.Size = UDim2.new(1, 0, 0, 52)
-	row.BackgroundColor3 = theme.surface
-	row.BorderSizePixel = 0
-	row.AutoButtonColor = false
-	row.Text = ""
-	row.LayoutOrder = product.LayoutOrder or 1
-	row.Parent = parent
+	-- Container (NO background, NO borders, NO card look!)
+	local container = Instance.new("Frame")
+	container.Name = product.name .. "Item"
+	container.Size = UDim2.new(1, 0, 0, 48)
+	container.BackgroundTransparency = 1
+	container.LayoutOrder = product.LayoutOrder or 1
+	container.Parent = parent
 
-	local corner = Instance.new("UICorner"); corner.CornerRadius = UDim.new(0, 12); corner.Parent = row
-	local stroke = Instance.new("UIStroke"); stroke.Color = accentColor; stroke.Thickness = 2; stroke.Transparency = 0.7; stroke.Parent = row
-
-	-- Hover effect
-	row.MouseEnter:Connect(function() 
-		playSound("hover")
-		TweenService:Create(stroke,TweenInfo.new(0.15),{Transparency=0.3}):Play()
-	end)
-	row.MouseLeave:Connect(function() 
-		TweenService:Create(stroke,TweenInfo.new(0.15),{Transparency=0.7}):Play()
-	end)
-
-	-- Icon on left
-	local icon = Instance.new("ImageLabel")
-	icon.Image = product.icon or "rbxassetid://0"
-	icon.Size = UDim2.fromOffset(36, 36)
-	icon.Position = UDim2.fromOffset(10, 8)
-	icon.BackgroundTransparency = 1
-	icon.Parent = row
-
-	-- Text area in middle
-	local textContainer = Instance.new("Frame")
-	textContainer.Size = UDim2.new(1, -160, 1, -10)
-	textContainer.Position = UDim2.fromOffset(52, 5)
-	textContainer.BackgroundTransparency = 1
-	textContainer.Parent = row
-
-	-- Product name
+	-- Name on the left
 	local nameLabel = Instance.new("TextLabel")
-	nameLabel.Size = UDim2.new(1, 0, 0, 18)
+	nameLabel.Size = UDim2.new(0.5, -10, 0, 20)
+	nameLabel.Position = UDim2.fromOffset(8, 4)
 	nameLabel.BackgroundTransparency = 1
 	nameLabel.Text = product.name
 	nameLabel.TextColor3 = theme.text
 	nameLabel.Font = Enum.Font.GothamBold
-	nameLabel.TextSize = 15
+	nameLabel.TextSize = 16
 	nameLabel.TextXAlignment = Enum.TextXAlignment.Left
 	nameLabel.TextTruncate = Enum.TextTruncate.AtEnd
-	nameLabel.Parent = textContainer
+	nameLabel.Parent = container
 
-	-- Amount/description
-	local descText = isGamepass and product.description or (formatNumber(product.amount) .. " Cash")
+	-- Amount/description below name
+	local descText = isGamepass and product.description or (formatNumber(product.amount))
 	local descLabel = Instance.new("TextLabel")
-	descLabel.Size = UDim2.new(1, 0, 0, 16)
-	descLabel.Position = UDim2.fromOffset(0, 20)
+	descLabel.Size = UDim2.new(0.5, -10, 0, 16)
+	descLabel.Position = UDim2.fromOffset(8, 26)
 	descLabel.BackgroundTransparency = 1
 	descLabel.Text = descText
 	descLabel.TextColor3 = theme.textSecondary
 	descLabel.Font = Enum.Font.Gotham
-	descLabel.TextSize = 11
+	descLabel.TextSize = 12
 	descLabel.TextXAlignment = Enum.TextXAlignment.Left
 	descLabel.TextTruncate = Enum.TextTruncate.AtEnd
-	descLabel.Parent = textContainer
+	descLabel.Parent = container
 
-	-- Button on right
+	-- Buy button - clean and flat
 	local buyBtn = Instance.new("TextButton")
-	buyBtn.Size = UDim2.fromOffset(100, 36)
-	buyBtn.Position = UDim2.new(1, -108, 0.5, 0)
+	buyBtn.Size = UDim2.fromOffset(90, 38)
+	buyBtn.Position = UDim2.new(1, -98, 0.5, 0)
 	buyBtn.AnchorPoint = Vector2.new(0, 0.5)
 	buyBtn.BackgroundColor3 = accentColor
 	buyBtn.Text = "R$" .. tostring(product.price or 0)
 	buyBtn.TextColor3 = Color3.new(1, 1, 1)
 	buyBtn.Font = Enum.Font.GothamBold
-	buyBtn.TextSize = 14
+	buyBtn.TextSize = 15
 	buyBtn.AutoButtonColor = false
-	buyBtn.Parent = row
-	local btnCorner = Instance.new("UICorner"); btnCorner.CornerRadius = UDim.new(0, 10); btnCorner.Parent = buyBtn
+	buyBtn.BorderSizePixel = 0
+	buyBtn.Parent = container
+	local btnCorner = Instance.new("UICorner"); btnCorner.CornerRadius = UDim.new(0, 8); btnCorner.Parent = buyBtn
+
+	-- Hover effect on button
+	buyBtn.MouseEnter:Connect(function()
+		playSound("hover")
+		TweenService:Create(buyBtn,TweenInfo.new(0.12),{BackgroundColor3=blend(accentColor, Color3.new(1,1,1), 0.2)}):Play()
+	end)
+	buyBtn.MouseLeave:Connect(function()
+		if not owned or (isGamepass and product.hasToggle) then
+			TweenService:Create(buyBtn,TweenInfo.new(0.12),{BackgroundColor3=accentColor}):Play()
+		end
+	end)
+
+	-- Separator line below
+	local line = Instance.new("Frame")
+	line.Size = UDim2.new(1, -16, 0, 1)
+	line.Position = UDim2.new(0, 8, 1, -1)
+	line.BackgroundColor3 = theme.stroke
+	line.BackgroundTransparency = 0.5
+	line.BorderSizePixel = 0
+	line.Parent = container
 
 	-- Toggle for Auto Collect
 	if isGamepass and product.hasToggle and owned then
-		buyBtn.Size = UDim2.fromOffset(80, 36)
-		buyBtn.Position = UDim2.new(1, -88, 0.5, 0)
+		buyBtn.Size = UDim2.fromOffset(70, 38)
+		buyBtn.Position = UDim2.new(1, -78, 0.5, 0)
 		buyBtn.Text = "OFF"
 		local state = false
 		if Remotes then
@@ -532,7 +524,7 @@ function Shop:createProductItem(product, productType, parent)
 		end)
 	end
 
-	product.cardInstance = row
+	product.cardInstance = container
 	product.purchaseButton = buyBtn
 end
 

--- a/SanrioShop_Perfect.lua
+++ b/SanrioShop_Perfect.lua
@@ -359,8 +359,9 @@ function Shop:createPages()
 		self.cashPage.CanvasSize = UDim2.new(0, 0, 0, cashGrid.AbsoluteContentSize.Y + 16)
 	end)
 
-	for _, p in ipairs(products.cash) do
-		self:createProductCard(p, "cash", self.cashPage)
+	for i, p in ipairs(products.cash) do
+		p.LayoutOrder = i
+		self:createProductItem(p, "cash", self.cashPage)
 	end
 
 	-- Gamepasses page
@@ -394,104 +395,99 @@ function Shop:createPages()
 		self.gpPage.CanvasSize = UDim2.new(0, 0, 0, gpGrid.AbsoluteContentSize.Y + 16)
 	end)
 
-	for _, gp in ipairs(products.gamepasses) do
-		self:createProductCard(gp, "gamepass", self.gpPage)
+	for i, gp in ipairs(products.gamepasses) do
+		gp.LayoutOrder = i
+		self:createProductItem(gp, "gamepass", self.gpPage)
 	end
 end
 
-function Shop:createProductCard(product, productType, parent)
+function Shop:createProductItem(product, productType, parent)
 	local isGamepass = (productType == "gamepass")
-	local cardColor = isGamepass and theme.kuromi or theme.cinna
+	local accentColor = isGamepass and theme.kuromi or theme.cinna
 	local owned = isGamepass and checkOwnership(product.id)
 
-	-- Simple flat card
-	local card = Instance.new("TextButton")
-	card.Name = product.name .. "Card"
-	card.BackgroundColor3 = blend(cardColor, Color3.new(1,1,1), 0.85)
-	card.BorderSizePixel = 0
-	card.AutoButtonColor = false
-	card.Text = ""
-	card.ClipsDescendants = true
-	card.Parent = parent
+	-- List item row
+	local row = Instance.new("TextButton")
+	row.Name = product.name .. "Row"
+	row.Size = UDim2.new(1, 0, 0, 52)
+	row.BackgroundColor3 = theme.surface
+	row.BorderSizePixel = 0
+	row.AutoButtonColor = false
+	row.Text = ""
+	row.LayoutOrder = product.LayoutOrder or 1
+	row.Parent = parent
 
-	local corner = Instance.new("UICorner"); corner.CornerRadius = UDim.new(0, 12); corner.Parent = card
+	local corner = Instance.new("UICorner"); corner.CornerRadius = UDim.new(0, 12); corner.Parent = row
+	local stroke = Instance.new("UIStroke"); stroke.Color = accentColor; stroke.Thickness = 2; stroke.Transparency = 0.7; stroke.Parent = row
 
 	-- Hover effect
-	local hoverScale = Instance.new("UIScale"); hoverScale.Scale = 1; hoverScale.Parent = card
-	card.MouseEnter:Connect(function() 
+	row.MouseEnter:Connect(function() 
 		playSound("hover")
-		TweenService:Create(hoverScale,TweenInfo.new(0.15),{Scale=1.03}):Play()
-		TweenService:Create(card,TweenInfo.new(0.15),{BackgroundColor3=blend(cardColor, Color3.new(1,1,1), 0.75)}):Play()
+		TweenService:Create(stroke,TweenInfo.new(0.15),{Transparency=0.3}):Play()
 	end)
-	card.MouseLeave:Connect(function() 
-		TweenService:Create(hoverScale,TweenInfo.new(0.15),{Scale=1}):Play()
-		TweenService:Create(card,TweenInfo.new(0.15),{BackgroundColor3=blend(cardColor, Color3.new(1,1,1), 0.85)}):Play()
+	row.MouseLeave:Connect(function() 
+		TweenService:Create(stroke,TweenInfo.new(0.15),{Transparency=0.7}):Play()
 	end)
 
-	-- Main text area
-	local textArea = Instance.new("Frame")
-	textArea.Size = UDim2.new(1, -16, 1, -36)
-	textArea.Position = UDim2.fromOffset(8, 8)
-	textArea.BackgroundTransparency = 1
-	textArea.Parent = card
+	-- Icon on left
+	local icon = Instance.new("ImageLabel")
+	icon.Image = product.icon or "rbxassetid://0"
+	icon.Size = UDim2.fromOffset(36, 36)
+	icon.Position = UDim2.fromOffset(10, 8)
+	icon.BackgroundTransparency = 1
+	icon.Parent = row
 
-	-- Product name (larger, centered)
+	-- Text area in middle
+	local textContainer = Instance.new("Frame")
+	textContainer.Size = UDim2.new(1, -160, 1, -10)
+	textContainer.Position = UDim2.fromOffset(52, 5)
+	textContainer.BackgroundTransparency = 1
+	textContainer.Parent = row
+
+	-- Product name
 	local nameLabel = Instance.new("TextLabel")
-	nameLabel.Size = UDim2.new(1, 0, 0, 20)
-	nameLabel.Position = UDim2.fromOffset(0, 10)
+	nameLabel.Size = UDim2.new(1, 0, 0, 18)
 	nameLabel.BackgroundTransparency = 1
 	nameLabel.Text = product.name
 	nameLabel.TextColor3 = theme.text
 	nameLabel.Font = Enum.Font.GothamBold
-	nameLabel.TextSize = 16
-	nameLabel.TextXAlignment = Enum.TextXAlignment.Center
+	nameLabel.TextSize = 15
+	nameLabel.TextXAlignment = Enum.TextXAlignment.Left
 	nameLabel.TextTruncate = Enum.TextTruncate.AtEnd
-	nameLabel.Parent = textArea
+	nameLabel.Parent = textContainer
 
-	-- Amount/Description
+	-- Amount/description
 	local descText = isGamepass and product.description or (formatNumber(product.amount) .. " Cash")
 	local descLabel = Instance.new("TextLabel")
-	descLabel.Size = UDim2.new(1, 0, 0, 32)
-	descLabel.Position = UDim2.fromOffset(0, 34)
+	descLabel.Size = UDim2.new(1, 0, 0, 16)
+	descLabel.Position = UDim2.fromOffset(0, 20)
 	descLabel.BackgroundTransparency = 1
 	descLabel.Text = descText
 	descLabel.TextColor3 = theme.textSecondary
 	descLabel.Font = Enum.Font.Gotham
-	descLabel.TextSize = 12
-	descLabel.TextXAlignment = Enum.TextXAlignment.Center
-	descLabel.TextWrapped = true
-	descLabel.Parent = textArea
+	descLabel.TextSize = 11
+	descLabel.TextXAlignment = Enum.TextXAlignment.Left
+	descLabel.TextTruncate = Enum.TextTruncate.AtEnd
+	descLabel.Parent = textContainer
 
-	-- Show OWNED text if gamepass is owned (above button area)
-	if isGamepass and owned and not product.hasToggle then
-		local ownedLabel = Instance.new("TextLabel")
-		ownedLabel.Size = UDim2.new(1, 0, 0, 16)
-		ownedLabel.Position = UDim2.new(0, 0, 1, -54)
-		ownedLabel.BackgroundTransparency = 1
-		ownedLabel.Text = "✓ OWNED"
-		ownedLabel.TextColor3 = theme.success
-		ownedLabel.Font = Enum.Font.GothamBold
-		ownedLabel.TextSize = 12
-		ownedLabel.TextXAlignment = Enum.TextXAlignment.Center
-		ownedLabel.Parent = card
-	end
-
-	-- Price/Buy button OR Toggle at bottom
+	-- Button on right
 	local buyBtn = Instance.new("TextButton")
-	buyBtn.Size = UDim2.new(1, -16, 0, 28)
-	buyBtn.Position = UDim2.new(0, 8, 1, -36)
-	buyBtn.BackgroundColor3 = cardColor
+	buyBtn.Size = UDim2.fromOffset(100, 36)
+	buyBtn.Position = UDim2.new(1, -108, 0.5, 0)
+	buyBtn.AnchorPoint = Vector2.new(0, 0.5)
+	buyBtn.BackgroundColor3 = accentColor
 	buyBtn.Text = "R$" .. tostring(product.price or 0)
 	buyBtn.TextColor3 = Color3.new(1, 1, 1)
 	buyBtn.Font = Enum.Font.GothamBold
 	buyBtn.TextSize = 14
 	buyBtn.AutoButtonColor = false
-	buyBtn.Active = true
-	buyBtn.Parent = card
+	buyBtn.Parent = row
 	local btnCorner = Instance.new("UICorner"); btnCorner.CornerRadius = UDim.new(0, 10); btnCorner.Parent = buyBtn
 
-	-- Toggle for Auto Collect (replaces button completely)
+	-- Toggle for Auto Collect
 	if isGamepass and product.hasToggle and owned then
+		buyBtn.Size = UDim2.fromOffset(80, 36)
+		buyBtn.Position = UDim2.new(1, -88, 0.5, 0)
 		buyBtn.Text = "OFF"
 		local state = false
 		if Remotes then
@@ -514,18 +510,6 @@ function Shop:createProductCard(product, productType, parent)
 		end
 		paint(state)
 		
-		-- Add OWNED label above toggle
-		local ownedLabel = Instance.new("TextLabel")
-		ownedLabel.Size = UDim2.new(1, 0, 0, 14)
-		ownedLabel.Position = UDim2.new(0, 0, 1, -52)
-		ownedLabel.BackgroundTransparency = 1
-		ownedLabel.Text = "✓ OWNED"
-		ownedLabel.TextColor3 = theme.success
-		ownedLabel.Font = Enum.Font.GothamBold
-		ownedLabel.TextSize = 10
-		ownedLabel.TextXAlignment = Enum.TextXAlignment.Center
-		ownedLabel.Parent = card
-		
 		buyBtn.MouseButton1Click:Connect(function()
 			local nextState = not state
 			paint(nextState)
@@ -536,12 +520,10 @@ function Shop:createProductCard(product, productType, parent)
 			end
 		end)
 	elseif isGamepass and owned then
-		-- Non-toggle gamepass that's owned
 		buyBtn.BackgroundColor3 = theme.success
-		buyBtn.Text = "✓ OWNED"
+		buyBtn.Text = "OWNED"
 		buyBtn.Active = false
 	else
-		-- Regular purchase button
 		buyBtn.MouseButton1Click:Connect(function()
 			if owned then return end
 			buyBtn.Text = "..."
@@ -550,11 +532,11 @@ function Shop:createProductCard(product, productType, parent)
 		end)
 	end
 
-	product.cardInstance = card
+	product.cardInstance = row
 	product.purchaseButton = buyBtn
 end
 
--- Toggle functionality is now integrated into createProductCard
+-- Toggle functionality is now integrated into createProductItem
 
 -- ✅ DYNAMIC SIZING (from first script)
 function Shop:setupDynamicSizing()

--- a/SanrioShop_Perfect.lua
+++ b/SanrioShop_Perfect.lua
@@ -1,0 +1,757 @@
+--[[
+    SANRIO SHOP — PERFECT MERGE
+    ✅ Beautiful pill buttons (from first script)
+    ✅ Full functionality (from second script)
+    
+    Features:
+    - Clean pill button design with crop images
+    - Purchase system with marketplace
+    - Auto-collect toggle
+    - Confetti + pulse effects
+    - Gift box button
+    - Mobile optimization
+    - Smart caching
+    - BEST VALUE ribbons
+--]]
+
+-- Services
+local Players = game:GetService("Players")
+local MarketplaceService = game:GetService("MarketplaceService")
+local TweenService = game:GetService("TweenService")
+local UserInputService = game:GetService("UserInputService")
+local GuiService = game:GetService("GuiService")
+local ReplicatedStorage = game:GetService("ReplicatedStorage")
+local ContentProvider = game:GetService("ContentProvider")
+local SoundService = game:GetService("SoundService")
+local Lighting = game:GetService("Lighting")
+local RunService = game:GetService("RunService")
+
+local Player = Players.LocalPlayer
+local PlayerGui = Player:WaitForChild("PlayerGui")
+local Remotes = ReplicatedStorage:FindFirstChild("TycoonRemotes")
+
+-- ======== ASSETS ========
+local IMG_FRAME = "rbxassetid://83301831904885"
+local IMG_GAMEPASSES = "rbxassetid://137846629770171"
+local IMG_CASH = "rbxassetid://84262748186110"
+local GIFT_BOX_TEXTURE_ID = "130623477775352" -- ← YOUR GIFT BOX
+
+-- ======== LAYOUT CONSTANTS (from first script) ========
+local FRAME_SCALE = 0.8
+local TAB_ROW_Y = 0.395
+local GP_ROW_EXTRA = 0.02
+local CONTENT_TOP_Y = 0.575
+local BAR_WIDTH_FACTOR = 0.86
+local CONTENT_WIDTH_FACTOR = 0.86
+local CONTENT_HEIGHT_FACTOR = 0.42
+
+-- Per-pill sizing
+local CASH_H_FACTOR = 0.09
+local GP_H_FACTOR = 0.095
+local PILL_MIN_H = 72
+local PILL_MAX_H = 120
+local CASH_RATIO = 2.85
+local GP_RATIO = 3.60
+
+-- ======== UTILITIES ========
+local function isMobile() return UserInputService.TouchEnabled and not GuiService:IsTenFootInterface() end
+local function isPhone() if not isMobile() then return false end; local cam=workspace.CurrentCamera; local v=cam.ViewportSize; return math.min(v.X,v.Y)<700 end
+local function formatNumber(n) local s=tostring(n); local k=1; while k~=0 do s,k=s:gsub("^(-?%d+)(%d%d%d)","%1,%2") end return s end
+local function blend(a,b,t) t=math.clamp(t,0,1); return Color3.new(a.R+(b.R-a.R)*t,a.G+(b.G-a.G)*t,a.B+(b.B-a.B)*t) end
+local function formatBonusText(b) return b and b > 0 and ("+%d%% Bonus"):format(math.floor(b*100)) or nil end
+
+-- ======== THEME ========
+local theme = {
+	background = Color3.fromRGB(253,252,250),
+	surface = Color3.fromRGB(255,255,255),
+	surfaceAlt = Color3.fromRGB(246,248,252),
+	stroke = Color3.fromRGB(222,226,235),
+	text = Color3.fromRGB(35,38,46),
+	textSecondary = Color3.fromRGB(120,126,140),
+	accent = Color3.fromRGB(255,80,140),
+	success = Color3.fromRGB(76,175,80),
+	cinna = Color3.fromRGB(186,214,255),
+	kuromi = Color3.fromRGB(200,190,255),
+}
+
+-- ======== CACHE ========
+local Cache = {}; Cache.__index = Cache
+function Cache.new(d) return setmetatable({data={},duration=d or 300},Cache) end
+function Cache:set(k,v) self.data[k]={v=v,t=tick()} end
+function Cache:get(k) local e=self.data[k]; if not e then return end; if tick()-e.t>self.duration then self.data[k]=nil; return end; return e.v end
+function Cache:clear(k) if k then self.data[k]=nil else self.data={} end end
+
+local productCache = Cache.new(300)
+local ownershipCache = Cache.new(60)
+
+-- ======== DATA ========
+local products = {
+	cash = {
+		{ id = 3366419712, amount = 1000,    name = "1,000 Cash",    description = "Includes 1,000 Cash",    icon = "rbxassetid://10709728059", price = 0 },
+		{ id = 3366420012, amount = 5000,    name = "5,000 Cash",    description = "Includes 5,000 Cash",    icon = "rbxassetid://10709728059", price = 0 },
+		{ id = 3366420478, amount = 10000,   name = "10,000 Cash",   description = "Includes 10,000 Cash",   icon = "rbxassetid://10709728059", price = 0, bonus = 0.10 },
+		{ id = 3366420800, amount = 25000,   name = "25,000 Cash",   description = "Includes 25,000 Cash",   icon = "rbxassetid://10709728059", price = 0 },
+		{ id = 3424973374, amount = 50000,   name = "50,000 Cash",   description = "Includes 50,000 Cash",   icon = "rbxassetid://10709728059", price = 0, bonus = 0.25 },
+		{ id = 3424974046, amount = 100000,  name = "100,000 Cash",  description = "Includes 100,000 Cash",  icon = "rbxassetid://10709728059", price = 0 },
+		{ id = 3424974161, amount = 250000,  name = "250,000 Cash",  description = "Includes 250,000 Cash",  icon = "rbxassetid://10709728059", price = 0 },
+		{ id = 3424974327, amount = 500000,  name = "500,000 Cash",  description = "Includes 500,000 Cash",  icon = "rbxassetid://10709728059", price = 0 },
+		{ id = 3424974402, amount = 1000000, name = "1,000,000 Cash",description = "Includes 1,000,000 Cash",icon = "rbxassetid://10709728059", price = 0, best = true, bonus = 0.35 },
+	},
+	gamepasses = {
+		{ id = 1412171840, name = "Auto Collect", description = "Automatically collect all cash drops", icon = "rbxassetid://10709727148", price = 99,  hasToggle = true  },
+		{ id = 1398974710, name = "2x Cash",      description = "Double all cash earned permanently",   icon = "rbxassetid://10709727148", price = 199, hasToggle = false },
+	},
+}
+
+local function getProductInfo(id)
+	local c=productCache:get(id); if c then return c end
+	local ok,info=pcall(function() return MarketplaceService:GetProductInfo(id,Enum.InfoType.Product) end)
+	if ok and info then productCache:set(id,info); return info end
+end
+
+local function getGamePassInfo(id)
+	local key="pass_"..id; local c=productCache:get(key); if c then return c end
+	local ok,info=pcall(function() return MarketplaceService:GetProductInfo(id,Enum.InfoType.GamePass) end)
+	if ok and info then productCache:set(key,info); return info end
+end
+
+local function checkOwnership(passId)
+	local key=("%d_%d"):format(Player.UserId,passId); local c=ownershipCache:get(key); if c~=nil then return c end
+	local ok,owns=pcall(function() return MarketplaceService:UserOwnsGamePassAsync(Player.UserId,passId) end)
+	if ok then ownershipCache:set(key,owns); return owns end; return false
+end
+
+local function refreshPrices()
+	for _,p in ipairs(products.cash) do local i=getProductInfo(p.id); if i and i.PriceInRobux then p.price=i.PriceInRobux end end
+	for _,gp in ipairs(products.gamepasses) do local i=getGamePassInfo(gp.id); if i and i.PriceInRobux then gp.price=i.PriceInRobux end end
+end
+
+-- ======== SOUND & EFFECTS ========
+local sounds = {}
+local function initSound()
+	local cfg={click={"rbxassetid://876939830",0.45},hover={"rbxassetid://10066936758",0.2},open={"rbxassetid://452267918",0.5},success={"rbxassetid://876939830",0.6}}
+	for name,data in pairs(cfg) do local s=Instance.new("Sound"); s.Name="SS_"..name; s.SoundId=data[1]; s.Volume=data[2]; s.Parent=SoundService; sounds[name]=s end
+end
+local function playSound(n) if sounds[n] then sounds[n]:Play() end end
+
+local function pulse(frame)
+	local s=frame:FindFirstChildOfClass("UIScale") or Instance.new("UIScale"); s.Parent=frame
+	TweenService:Create(s,TweenInfo.new(0.1),{Scale=1.06}):Play(); task.delay(0.1,function() TweenService:Create(s,TweenInfo.new(0.18),{Scale=1}):Play() end)
+end
+
+local function confetti(parent)
+	for i=1,8 do
+		local chip=Instance.new("Frame"); chip.BackgroundColor3=(i%2==0) and theme.accent or theme.kuromi; chip.Size=UDim2.fromOffset(6,10); chip.Position=UDim2.new(math.random(),0,0,-6); chip.BorderSizePixel=0; chip.Parent=parent
+		local c=Instance.new("UICorner"); c.CornerRadius=UDim.new(0,2); c.Parent=chip
+		task.spawn(function() TweenService:Create(chip,TweenInfo.new(0.45),{Position=UDim2.new(chip.Position.X.Scale,(math.random()-0.5)*60,0,math.random(60,110)),Rotation=math.random(-40,40)}):Play(); task.delay(0.46,function() chip:Destroy() end) end)
+	end
+end
+
+-- ======== SHOP CLASS ========
+local Shop = {}
+Shop.__index = Shop
+
+function Shop.new()
+	local self = setmetatable({}, Shop)
+	self.gui = nil
+	self.mainFrame = nil
+	self.buttonBar = nil
+	self.cashContainer = nil
+	self.gpContainer = nil
+	self.cashBtn = nil
+	self.gpBtn = nil
+	self.contentFrame = nil
+	self.cashPage = nil
+	self.gpPage = nil
+	self.toggleButton = nil
+	self.blur = nil
+	self.isOpen = false
+	self.purchasePending = {}
+	return self
+end
+
+function Shop:initialize()
+	initSound()
+	refreshPrices()
+	self:createToggleButton()
+	self:createMainInterface()
+	self:setupHandlers()
+	print("[SanrioShop] ✅ Perfect merge loaded!")
+end
+
+function Shop:createToggleButton()
+	local sg = Instance.new("ScreenGui")
+	sg.Name = "SanrioShopToggle"
+	sg.ResetOnSpawn = false
+	sg.DisplayOrder = 999
+	sg.ScreenInsets = Enum.ScreenInsets.DeviceSafeInsets
+	sg.Parent = PlayerGui
+
+	local size = isPhone() and UDim2.fromOffset(70,70) or UDim2.fromOffset(90,90)
+	local pos = isPhone() and UDim2.new(1,-16,0,76) or UDim2.new(1,-16,0.5,-70)
+	local anchor = isPhone() and Vector2.new(1,0) or Vector2.new(1,0.5)
+
+	self.toggleButton = Instance.new("TextButton")
+	self.toggleButton.Size = size
+	self.toggleButton.Position = pos
+	self.toggleButton.AnchorPoint = anchor
+	self.toggleButton.BackgroundColor3 = theme.surface
+	self.toggleButton.Text = ""
+	self.toggleButton.AutoButtonColor = false
+	self.toggleButton.Parent = sg
+
+	local corner = Instance.new("UICorner"); corner.CornerRadius = UDim.new(0,16); corner.Parent = self.toggleButton
+	local stroke = Instance.new("UIStroke"); stroke.Color = theme.accent; stroke.Thickness = 2; stroke.Parent = self.toggleButton
+
+	local giftSize = isPhone() and 56 or 72
+	local img = Instance.new("ImageLabel")
+	img.Image = "rbxassetid://" .. GIFT_BOX_TEXTURE_ID
+	img.Size = UDim2.fromOffset(giftSize, giftSize)
+	img.Position = UDim2.fromScale(0.5, 0.5)
+	img.AnchorPoint = Vector2.new(0.5, 0.5)
+	img.BackgroundTransparency = 1
+	img.Parent = self.toggleButton
+
+	self.toggleButton.MouseButton1Click:Connect(function() self:toggle() end)
+end
+
+-- ✅ PILL BUTTON CREATION (from first script)
+function Shop:makePill(name, imageId, ratio)
+	local container = Instance.new("Frame")
+	container.Name = name .. "Container"
+	container.BackgroundTransparency = 1
+	container.AnchorPoint = Vector2.new(0.5, 0.5)
+	container.Size = UDim2.fromOffset(260, 86)
+	container.ZIndex = 6
+	container.Parent = self.buttonBar
+
+	local ar = Instance.new("UIAspectRatioConstraint")
+	ar.AspectRatio = ratio
+	ar.DominantAxis = Enum.DominantAxis.Width
+	ar.Parent = container
+
+	local btn = Instance.new("ImageButton")
+	btn.Name = name .. "Button"
+	btn.BackgroundTransparency = 1
+	btn.AutoButtonColor = false
+	btn.Size = UDim2.fromScale(1, 1)
+	btn.Image = imageId
+	btn.ScaleType = Enum.ScaleType.Crop
+	btn.ZIndex = 7
+	btn.Parent = container
+
+	local function bump(mult)
+		local sx = math.floor(container.Size.X.Offset * mult)
+		local sy = math.floor(container.Size.Y.Offset * mult)
+		TweenService:Create(container, TweenInfo.new(0.12, Enum.EasingStyle.Quad, Enum.EasingDirection.Out),
+			{Size = UDim2.fromOffset(sx, sy)}):Play()
+	end
+
+	btn.MouseEnter:Connect(function() playSound("hover"); bump(1.02) end)
+	btn.MouseLeave:Connect(function() bump(1.00) end)
+	btn.MouseButton1Down:Connect(function() bump(0.98) end)
+	btn.MouseButton1Up:Connect(function() bump(1.02) end)
+
+	return container, btn
+end
+
+function Shop:createMainInterface()
+	-- Main ScreenGui
+	self.gui = Instance.new("ScreenGui")
+	self.gui.Name = "SanrioShopMain"
+	self.gui.ResetOnSpawn = false
+	self.gui.DisplayOrder = 1000
+	self.gui.Enabled = false
+	self.gui.IgnoreGuiInset = true
+	self.gui.Parent = PlayerGui
+
+	-- Blur
+	self.blur = Lighting:FindFirstChild("SanrioShopBlur") or Instance.new("BlurEffect")
+	self.blur.Name = "SanrioShopBlur"
+	self.blur.Size = 0
+	self.blur.Parent = Lighting
+
+	-- Dim background
+	local dim = Instance.new("Frame")
+	dim.Size = UDim2.fromScale(1, 1)
+	dim.BackgroundColor3 = Color3.new(0, 0, 0)
+	dim.BackgroundTransparency = 0.38
+	dim.BorderSizePixel = 0
+	dim.Parent = self.gui
+
+	-- ✅ Main frame with background image (from first script)
+	self.mainFrame = Instance.new("ImageLabel")
+	self.mainFrame.Name = "MainFrame"
+	self.mainFrame.BackgroundTransparency = 1
+	self.mainFrame.AnchorPoint = Vector2.new(0.5, 0.5)
+	self.mainFrame.Position = UDim2.fromScale(0.5, 0.5)
+	self.mainFrame.Size = UDim2.fromScale(FRAME_SCALE, FRAME_SCALE)
+	self.mainFrame.Image = IMG_FRAME
+	self.mainFrame.ScaleType = Enum.ScaleType.Fit
+	self.mainFrame.ZIndex = 1
+	self.mainFrame.Parent = self.gui
+
+	local aspect = Instance.new("UIAspectRatioConstraint")
+	aspect.AspectRatio = 1
+	aspect.Parent = self.mainFrame
+
+	-- ✅ Button bar (from first script)
+	self.buttonBar = Instance.new("Frame")
+	self.buttonBar.Name = "ButtonBar"
+	self.buttonBar.BackgroundTransparency = 1
+	self.buttonBar.AnchorPoint = Vector2.new(0.5, 0)
+	self.buttonBar.Position = UDim2.fromScale(0.5, TAB_ROW_Y)
+	self.buttonBar.Size = UDim2.fromScale(BAR_WIDTH_FACTOR, 0)
+	self.buttonBar.ZIndex = 5
+	self.buttonBar.Parent = self.mainFrame
+
+	-- ✅ Create pill buttons (from first script)
+	self.cashContainer, self.cashBtn = self:makePill("Cash", IMG_CASH, CASH_RATIO)
+	self.gpContainer, self.gpBtn = self:makePill("Gamepasses", IMG_GAMEPASSES, GP_RATIO)
+
+	-- ✅ Content frame (from first script)
+	self.contentFrame = Instance.new("Frame")
+	self.contentFrame.Name = "Content"
+	self.contentFrame.AnchorPoint = Vector2.new(0.5, 0)
+	self.contentFrame.Position = UDim2.fromScale(0.5, CONTENT_TOP_Y)
+	self.contentFrame.Size = UDim2.fromScale(CONTENT_WIDTH_FACTOR, CONTENT_HEIGHT_FACTOR)
+	self.contentFrame.BackgroundColor3 = Color3.fromRGB(255, 255, 255)
+	self.contentFrame.BackgroundTransparency = 0.88
+	self.contentFrame.ZIndex = 3
+	self.contentFrame.Parent = self.mainFrame
+
+	local contentCorner = Instance.new("UICorner")
+	contentCorner.CornerRadius = UDim.new(0, 20)
+	contentCorner.Parent = self.contentFrame
+
+	-- Create pages
+	self:createPages()
+
+	-- ✅ Setup dynamic sizing (from first script)
+	self:setupDynamicSizing()
+
+	-- Wire button clicks
+	self.cashBtn.MouseButton1Click:Connect(function() self:showCash() end)
+	self.gpBtn.MouseButton1Click:Connect(function() self:showGamepasses() end)
+end
+
+function Shop:createPages()
+	-- Cash page
+	self.cashPage = Instance.new("ScrollingFrame")
+	self.cashPage.Name = "CashPage"
+	self.cashPage.BackgroundTransparency = 1
+	self.cashPage.BorderSizePixel = 0
+	self.cashPage.ScrollBarThickness = 6
+	self.cashPage.ScrollBarImageColor3 = theme.accent
+	self.cashPage.Visible = true
+	self.cashPage.Size = UDim2.fromScale(1, 1)
+	self.cashPage.ZIndex = 4
+	self.cashPage.Parent = self.contentFrame
+
+	local cashGrid = Instance.new("UIGridLayout")
+	cashGrid.CellSize = UDim2.new(0.48, 0, 0, 110)
+	cashGrid.CellPadding = UDim2.fromOffset(12, 12)
+	cashGrid.HorizontalAlignment = Enum.HorizontalAlignment.Center
+	cashGrid.SortOrder = Enum.SortOrder.LayoutOrder
+	cashGrid.Parent = self.cashPage
+
+	cashGrid:GetPropertyChangedSignal("AbsoluteContentSize"):Connect(function()
+		self.cashPage.CanvasSize = UDim2.new(0, 0, 0, cashGrid.AbsoluteContentSize.Y + 20)
+	end)
+
+	for _, p in ipairs(products.cash) do
+		self:createProductCard(p, "cash", self.cashPage)
+	end
+
+	-- Gamepasses page
+	self.gpPage = Instance.new("ScrollingFrame")
+	self.gpPage.Name = "GamepassPage"
+	self.gpPage.BackgroundTransparency = 1
+	self.gpPage.BorderSizePixel = 0
+	self.gpPage.ScrollBarThickness = 6
+	self.gpPage.ScrollBarImageColor3 = theme.accent
+	self.gpPage.Visible = false
+	self.gpPage.Size = UDim2.fromScale(1, 1)
+	self.gpPage.ZIndex = 4
+	self.gpPage.Parent = self.contentFrame
+
+	local gpGrid = Instance.new("UIGridLayout")
+	gpGrid.CellSize = UDim2.new(0.48, 0, 0, 110)
+	gpGrid.CellPadding = UDim2.fromOffset(12, 12)
+	gpGrid.HorizontalAlignment = Enum.HorizontalAlignment.Center
+	gpGrid.SortOrder = Enum.SortOrder.LayoutOrder
+	gpGrid.Parent = self.gpPage
+
+	gpGrid:GetPropertyChangedSignal("AbsoluteContentSize"):Connect(function()
+		self.gpPage.CanvasSize = UDim2.new(0, 0, 0, gpGrid.AbsoluteContentSize.Y + 20)
+	end)
+
+	for _, gp in ipairs(products.gamepasses) do
+		self:createProductCard(gp, "gamepass", self.gpPage)
+	end
+end
+
+function Shop:createProductCard(product, productType, parent)
+	local isGamepass = (productType == "gamepass")
+	local cardColor = isGamepass and theme.kuromi or theme.cinna
+
+	local card = Instance.new("Frame")
+	card.Name = product.name .. "Card"
+	card.BackgroundColor3 = theme.surface
+	card.BorderSizePixel = 0
+	card.ClipsDescendants = true
+	card.Parent = parent
+
+	local corner = Instance.new("UICorner"); corner.CornerRadius = UDim.new(0, 14); corner.Parent = card
+	local stroke = Instance.new("UIStroke"); stroke.Color = cardColor; stroke.Thickness = 2; stroke.Transparency = 0.45; stroke.Parent = card
+
+	local hoverScale = Instance.new("UIScale"); hoverScale.Scale = 1; hoverScale.Parent = card
+	card.MouseEnter:Connect(function() playSound("hover"); TweenService:Create(hoverScale,TweenInfo.new(0.15),{Scale=1.03}):Play() end)
+	card.MouseLeave:Connect(function() TweenService:Create(hoverScale,TweenInfo.new(0.15),{Scale=1}):Play() end)
+
+	-- Image area
+	local imgContainer = Instance.new("Frame")
+	imgContainer.Size = UDim2.new(1, 0, 0, 50)
+	imgContainer.Position = UDim2.fromOffset(0, 4)
+	imgContainer.BackgroundColor3 = theme.surfaceAlt
+	imgContainer.BorderSizePixel = 0
+	imgContainer.Parent = card
+	local imgCorner = Instance.new("UICorner"); imgCorner.CornerRadius = UDim.new(0, 10); imgCorner.Parent = imgContainer
+
+	local img = Instance.new("ImageLabel")
+	img.Image = product.icon or "rbxassetid://0"
+	img.Size = UDim2.fromScale(0.6, 0.6)
+	img.Position = UDim2.fromScale(0.5, 0.5)
+	img.AnchorPoint = Vector2.new(0.5, 0.5)
+	img.BackgroundTransparency = 1
+	img.Parent = imgContainer
+
+	-- BEST VALUE ribbon
+	if not isGamepass and product.best then
+		local ribbon = Instance.new("TextLabel")
+		ribbon.BackgroundColor3 = theme.accent
+		ribbon.Text = "BEST"
+		ribbon.TextColor3 = Color3.new(1,1,1)
+		ribbon.Font = Enum.Font.GothamBold
+		ribbon.TextSize = 10
+		ribbon.Size = UDim2.fromOffset(38, 16)
+		ribbon.Position = UDim2.fromOffset(4, 4)
+		ribbon.Parent = imgContainer
+		local c = Instance.new("UICorner"); c.CornerRadius = UDim.new(0, 6); c.Parent = ribbon
+	end
+
+	-- Title
+	local title = Instance.new("TextLabel")
+	title.Size = UDim2.new(1, -12, 0, 18)
+	title.Position = UDim2.fromOffset(6, 58)
+	title.BackgroundTransparency = 1
+	title.Text = product.name
+	title.TextColor3 = theme.text
+	title.Font = Enum.Font.GothamBold
+	title.TextSize = 14
+	title.TextXAlignment = Enum.TextXAlignment.Left
+	title.TextTruncate = Enum.TextTruncate.AtEnd
+	title.Parent = card
+
+	-- Description
+	local desc = Instance.new("TextLabel")
+	desc.Size = UDim2.new(1, -12, 0, 16)
+	desc.Position = UDim2.fromOffset(6, 78)
+	desc.BackgroundTransparency = 1
+	desc.Text = isGamepass and product.description or (formatNumber(product.amount) .. " Cash")
+	desc.TextColor3 = theme.textSecondary
+	desc.Font = Enum.Font.Gotham
+	desc.TextSize = 11
+	desc.TextXAlignment = Enum.TextXAlignment.Left
+	desc.TextTruncate = Enum.TextTruncate.AtEnd
+	desc.Parent = card
+
+	-- Bonus label
+	if not isGamepass and product.bonus and product.bonus > 0 then
+		local bonus = Instance.new("TextLabel")
+		bonus.Size = UDim2.new(1, -12, 0, 14)
+		bonus.Position = UDim2.fromOffset(6, 94)
+		bonus.BackgroundTransparency = 1
+		bonus.Text = formatBonusText(product.bonus)
+		bonus.TextColor3 = theme.accent
+		bonus.Font = Enum.Font.Gotham
+		bonus.TextSize = 10
+		bonus.TextXAlignment = Enum.TextXAlignment.Left
+		bonus.Parent = card
+	end
+
+	-- Buy button
+	local owned = isGamepass and checkOwnership(product.id)
+	local buyBtn = Instance.new("TextButton")
+	buyBtn.Size = UDim2.new(1, -12, 0, 26)
+	buyBtn.Position = UDim2.new(0, 6, 1, -30)
+	buyBtn.BackgroundColor3 = owned and theme.success or cardColor
+	buyBtn.Text = owned and "✓ Owned" or ("R$" .. tostring(product.price or 0))
+	buyBtn.TextColor3 = Color3.new(1, 1, 1)
+	buyBtn.Font = Enum.Font.GothamBold
+	buyBtn.TextSize = 13
+	buyBtn.AutoButtonColor = false
+	buyBtn.Active = not owned
+	buyBtn.Parent = card
+	local btnCorner = Instance.new("UICorner"); btnCorner.CornerRadius = UDim.new(0, 8); btnCorner.Parent = buyBtn
+
+	buyBtn.MouseButton1Click:Connect(function()
+		if owned then return end
+		buyBtn.Text = "..."
+		buyBtn.Active = false
+		self:promptPurchase(product, productType, buyBtn)
+	end)
+
+	-- Toggle for Auto Collect
+	if isGamepass and product.hasToggle and owned then
+		self:addToggleSwitch(product, imgContainer)
+	end
+
+	product.cardInstance = card
+	product.purchaseButton = buyBtn
+end
+
+function Shop:addToggleSwitch(product, parent)
+	local toggle = Instance.new("Frame")
+	toggle.Size = UDim2.fromOffset(110, 22)
+	toggle.Position = UDim2.new(1, -4, 0, 4)
+	toggle.AnchorPoint = Vector2.new(1, 0)
+	toggle.BackgroundColor3 = theme.surface
+	toggle.BorderSizePixel = 0
+	toggle.Parent = parent
+	local tc = Instance.new("UICorner"); tc.CornerRadius = UDim.new(0, 11); tc.Parent = toggle
+	local ts = Instance.new("UIStroke"); ts.Color = theme.stroke; ts.Thickness = 1; ts.Parent = toggle
+
+	local label = Instance.new("TextLabel")
+	label.Size = UDim2.fromScale(1, 1)
+	label.BackgroundTransparency = 1
+	label.Text = "Auto: OFF"
+	label.TextColor3 = theme.text
+	label.Font = Enum.Font.GothamBold
+	label.TextSize = 10
+	label.Parent = toggle
+
+	local btn = Instance.new("TextButton")
+	btn.Size = UDim2.fromScale(1, 1)
+	btn.BackgroundTransparency = 1
+	btn.Text = ""
+	btn.Parent = toggle
+
+	local state = false
+	if Remotes then
+		local rf = Remotes:FindFirstChild("GetAutoCollectState")
+		if rf and rf:IsA("RemoteFunction") then
+			local ok, val = pcall(function() return rf:InvokeServer() end)
+			if ok and type(val) == "boolean" then state = val end
+		end
+	end
+
+	local function paint(on)
+		state = on
+		if on then
+			toggle.BackgroundColor3 = theme.success
+			ts.Color = theme.success
+			label.TextColor3 = Color3.new(1, 1, 1)
+			label.Text = "Auto: ON"
+		else
+			toggle.BackgroundColor3 = theme.surface
+			ts.Color = theme.stroke
+			label.TextColor3 = theme.text
+			label.Text = "Auto: OFF"
+		end
+	end
+
+	paint(state)
+
+	btn.MouseButton1Click:Connect(function()
+		local nextState = not state
+		paint(nextState)
+		playSound("click")
+		if Remotes then
+			local ev = Remotes:FindFirstChild("AutoCollectToggle")
+			if ev and ev:IsA("RemoteEvent") then ev:FireServer(nextState) end
+		end
+	end)
+end
+
+-- ✅ DYNAMIC SIZING (from first script)
+function Shop:setupDynamicSizing()
+	local function resize()
+		local H = self.mainFrame.AbsoluteSize.Y
+		if H <= 0 then return end
+
+		local cashH = math.clamp(math.floor(H * CASH_H_FACTOR), PILL_MIN_H, PILL_MAX_H)
+		local gpH = math.clamp(math.floor(H * GP_H_FACTOR), PILL_MIN_H, PILL_MAX_H)
+		local barH = math.max(cashH, gpH)
+
+		self.buttonBar.Size = UDim2.new(0, math.floor(H * BAR_WIDTH_FACTOR), 0, barH)
+
+		local cashW = math.floor(cashH * CASH_RATIO)
+		self.cashContainer.Size = UDim2.fromOffset(cashW, cashH)
+		self.cashContainer.Position = UDim2.fromScale(0.30, 0.50)
+
+		local gpW = math.floor(gpH * GP_RATIO)
+		self.gpContainer.Size = UDim2.fromOffset(gpW, gpH)
+		self.gpContainer.Position = UDim2.fromScale(0.70, 0.50 + GP_ROW_EXTRA)
+
+		self.contentFrame.Size = UDim2.new(0, math.floor(H * CONTENT_WIDTH_FACTOR), 0, math.floor(H * CONTENT_HEIGHT_FACTOR))
+		self.contentFrame.Position = UDim2.fromScale(0.5, CONTENT_TOP_Y)
+	end
+
+	self.mainFrame:GetPropertyChangedSignal("AbsoluteSize"):Connect(resize)
+	RunService.Heartbeat:Connect(resize)
+	task.defer(resize)
+end
+
+function Shop:showCash()
+	self.cashPage.Visible = true
+	self.gpPage.Visible = false
+	playSound("click")
+end
+
+function Shop:showGamepasses()
+	self.cashPage.Visible = false
+	self.gpPage.Visible = true
+	playSound("click")
+end
+
+function Shop:promptPurchase(product, kind, button)
+	self.purchasePending[product.id] = { product = product, type = kind, button = button }
+	local ok
+	if kind == "gamepass" then
+		ok = pcall(function() MarketplaceService:PromptGamePassPurchase(Player, product.id) end)
+	else
+		ok = pcall(function() MarketplaceService:PromptProductPurchase(Player, product.id) end)
+	end
+	if not ok then
+		if button and button.Parent then
+			button.Text = "R$" .. tostring(product.price or 0)
+			button.Active = true
+		end
+		self.purchasePending[product.id] = nil
+	end
+end
+
+function Shop:refreshAllProducts()
+	ownershipCache:clear()
+	for _, gp in ipairs(products.gamepasses) do
+		local owned = checkOwnership(gp.id)
+		if gp.purchaseButton then
+			gp.purchaseButton.Text = owned and "✓ Owned" or ("R$" .. tostring(gp.price or 0))
+			gp.purchaseButton.BackgroundColor3 = owned and theme.success or theme.kuromi
+			gp.purchaseButton.Active = not owned
+		end
+	end
+end
+
+function Shop:open()
+	if self.isOpen then return end
+	self.isOpen = true
+	ownershipCache:clear()
+	refreshPrices()
+	self:refreshAllProducts()
+
+	self.gui.Enabled = true
+	TweenService:Create(self.blur, TweenInfo.new(0.25), {Size = 24}):Play()
+
+	self.mainFrame.Position = UDim2.fromScale(0.5, 0.52)
+	TweenService:Create(self.mainFrame, TweenInfo.new(0.3, Enum.EasingStyle.Back), {
+		Position = UDim2.fromScale(0.5, 0.5)
+	}):Play()
+
+	self:showCash()
+	playSound("open")
+end
+
+function Shop:close()
+	if not self.isOpen then return end
+	self.isOpen = false
+	TweenService:Create(self.blur, TweenInfo.new(0.15), {Size = 0}):Play()
+	TweenService:Create(self.mainFrame, TweenInfo.new(0.15), {
+		Position = UDim2.fromScale(0.5, 0.52)
+	}):Play()
+	task.wait(0.15)
+	self.gui.Enabled = false
+end
+
+function Shop:toggle()
+	if self.isOpen then
+		self:close()
+	else
+		self:open()
+	end
+end
+
+function Shop:setupHandlers()
+	-- Input
+	UserInputService.InputBegan:Connect(function(i, gp)
+		if gp then return end
+		if i.KeyCode == Enum.KeyCode.M then self:toggle() end
+		if i.KeyCode == Enum.KeyCode.Escape and self.isOpen then self:close() end
+	end)
+
+	-- Remotes
+	if Remotes then
+		local gpPurchased = Remotes:FindFirstChild("GamepassPurchased")
+		if gpPurchased and gpPurchased:IsA("RemoteEvent") then
+			gpPurchased.OnClientEvent:Connect(function()
+				task.wait(0.5)
+				self:refreshAllProducts()
+				playSound("success")
+			end)
+		end
+	end
+
+	-- Purchase callbacks
+	MarketplaceService.PromptGamePassPurchaseFinished:Connect(function(player, passId, purchased)
+		if player ~= Player then return end
+		local p = self.purchasePending[passId]
+		if p and p.button and p.button.Parent then
+			p.button.Text = purchased and "✓ Owned" or ("R$" .. tostring(p.product.price or 0))
+			p.button.Active = not purchased
+		end
+		self.purchasePending[passId] = nil
+		if purchased then
+			ownershipCache:clear()
+			task.wait(0.8)
+			self:refreshAllProducts()
+			playSound("success")
+			if p and p.product and p.product.cardInstance then
+				pulse(p.product.cardInstance)
+				confetti(p.product.cardInstance)
+			end
+		end
+	end)
+
+	MarketplaceService.PromptProductPurchaseFinished:Connect(function(player, productId, purchased)
+		if player ~= Player then return end
+		local p = self.purchasePending[productId]
+		if p and p.button and p.button.Parent then
+			p.button.Text = "R$" .. tostring(p.product.price or 0)
+			p.button.Active = true
+		end
+		self.purchasePending[productId] = nil
+		if purchased then
+			playSound("success")
+			if p and p.product and p.product.cardInstance then
+				pulse(p.product.cardInstance)
+				confetti(p.product.cardInstance)
+			end
+		end
+	end)
+end
+
+-- ======== BOOT ========
+local shop = Shop.new()
+shop:initialize()
+
+Player.CharacterAdded:Connect(function()
+	task.wait(1)
+	if not shop.toggleButton or not shop.toggleButton.Parent then
+		shop:createToggleButton()
+	end
+end)
+
+print("[SanrioShop] ✨ PERFECT MERGE: Beautiful pills + Full functionality!")
+print("[SanrioShop] 🎁 Gift box texture:", GIFT_BOX_TEXTURE_ID)
+return shop

--- a/SanrioShop_Perfect.lua
+++ b/SanrioShop_Perfect.lua
@@ -38,12 +38,12 @@ local GIFT_BOX_TEXTURE_ID = "130623477775352" -- ← YOUR GIFT BOX
 
 -- ======== LAYOUT CONSTANTS (from first script) ========
 local FRAME_SCALE = 0.8
-local TAB_ROW_Y = 0.395
+local TAB_ROW_Y = 0.36
 local GP_ROW_EXTRA = 0.02
-local CONTENT_TOP_Y = 0.575
+local CONTENT_TOP_Y = 0.50
 local BAR_WIDTH_FACTOR = 0.86
 local CONTENT_WIDTH_FACTOR = 0.86
-local CONTENT_HEIGHT_FACTOR = 0.42
+local CONTENT_HEIGHT_FACTOR = 0.45
 
 -- Per-pill sizing
 local CASH_H_FACTOR = 0.09
@@ -349,7 +349,7 @@ function Shop:createPages()
 	self.cashPage.Parent = self.contentFrame
 
 	local cashGrid = Instance.new("UIGridLayout")
-	cashGrid.CellSize = UDim2.new(0.48, 0, 0, 110)
+	cashGrid.CellSize = UDim2.new(0.48, 0, 0, 105)
 	cashGrid.CellPadding = UDim2.fromOffset(12, 12)
 	cashGrid.HorizontalAlignment = Enum.HorizontalAlignment.Center
 	cashGrid.SortOrder = Enum.SortOrder.LayoutOrder
@@ -384,7 +384,7 @@ function Shop:createPages()
 	gpPad.Parent = self.gpPage
 
 	local gpGrid = Instance.new("UIGridLayout")
-	gpGrid.CellSize = UDim2.new(0.48, 0, 0, 130)
+	gpGrid.CellSize = UDim2.new(0.48, 0, 0, 105)
 	gpGrid.CellPadding = UDim2.fromOffset(10, 10)
 	gpGrid.HorizontalAlignment = Enum.HorizontalAlignment.Center
 	gpGrid.SortOrder = Enum.SortOrder.LayoutOrder
@@ -402,15 +402,16 @@ end
 function Shop:createProductCard(product, productType, parent)
 	local isGamepass = (productType == "gamepass")
 	local cardColor = isGamepass and theme.kuromi or theme.cinna
+	local owned = isGamepass and checkOwnership(product.id)
 
-	-- Main card container
+	-- Simple flat card
 	local card = Instance.new("TextButton")
 	card.Name = product.name .. "Card"
-	card.BackgroundColor3 = cardColor
+	card.BackgroundColor3 = blend(cardColor, Color3.new(1,1,1), 0.85)
 	card.BorderSizePixel = 0
 	card.AutoButtonColor = false
 	card.Text = ""
-	card.ClipsDescendants = false
+	card.ClipsDescendants = true
 	card.Parent = parent
 
 	local corner = Instance.new("UICorner"); corner.CornerRadius = UDim.new(0, 12); corner.Parent = card
@@ -419,202 +420,111 @@ function Shop:createProductCard(product, productType, parent)
 	local hoverScale = Instance.new("UIScale"); hoverScale.Scale = 1; hoverScale.Parent = card
 	card.MouseEnter:Connect(function() 
 		playSound("hover")
-		TweenService:Create(hoverScale,TweenInfo.new(0.12),{Scale=1.04}):Play() 
+		TweenService:Create(hoverScale,TweenInfo.new(0.15),{Scale=1.03}):Play()
+		TweenService:Create(card,TweenInfo.new(0.15),{BackgroundColor3=blend(cardColor, Color3.new(1,1,1), 0.75)}):Play()
 	end)
 	card.MouseLeave:Connect(function() 
-		TweenService:Create(hoverScale,TweenInfo.new(0.12),{Scale=1}):Play() 
+		TweenService:Create(hoverScale,TweenInfo.new(0.15),{Scale=1}):Play()
+		TweenService:Create(card,TweenInfo.new(0.15),{BackgroundColor3=blend(cardColor, Color3.new(1,1,1), 0.85)}):Play()
 	end)
 
-	-- Inner content with padding
-	local content = Instance.new("Frame")
-	content.Size = UDim2.new(1, -8, 1, -8)
-	content.Position = UDim2.fromOffset(4, 4)
-	content.BackgroundColor3 = theme.surface
-	content.BorderSizePixel = 0
-	content.Parent = card
-	local contentCorner = Instance.new("UICorner"); contentCorner.CornerRadius = UDim.new(0, 10); contentCorner.Parent = content
+	-- Main text area
+	local textArea = Instance.new("Frame")
+	textArea.Size = UDim2.new(1, -16, 1, -36)
+	textArea.Position = UDim2.fromOffset(8, 8)
+	textArea.BackgroundTransparency = 1
+	textArea.Parent = card
 
-	-- BEST VALUE corner badge
-	if not isGamepass and product.best then
-		local badge = Instance.new("TextLabel")
-		badge.BackgroundColor3 = theme.accent
-		badge.Text = "BEST"
-		badge.TextColor3 = Color3.new(1,1,1)
-		badge.Font = Enum.Font.GothamBold
-		badge.TextSize = 9
-		badge.Size = UDim2.fromOffset(34, 14)
-		badge.Position = UDim2.fromOffset(4, 4)
-		badge.Parent = content
-		local bc = Instance.new("UICorner"); bc.CornerRadius = UDim.new(0, 4); bc.Parent = badge
-	end
-
-	-- Product icon
-	local icon = Instance.new("ImageLabel")
-	icon.Image = product.icon or "rbxassetid://0"
-	icon.Size = UDim2.fromOffset(32, 32)
-	icon.Position = UDim2.fromScale(0.5, 0)
-	icon.AnchorPoint = Vector2.new(0.5, 0)
-	icon.Position = UDim2.new(0.5, 0, 0, 8)
-	icon.BackgroundTransparency = 1
-	icon.Parent = content
-
-	-- Product name
+	-- Product name (larger, centered)
 	local nameLabel = Instance.new("TextLabel")
-	nameLabel.Size = UDim2.new(1, -8, 0, 16)
-	nameLabel.Position = UDim2.fromOffset(4, 46)
+	nameLabel.Size = UDim2.new(1, 0, 0, 20)
+	nameLabel.Position = UDim2.fromOffset(0, 10)
 	nameLabel.BackgroundTransparency = 1
 	nameLabel.Text = product.name
 	nameLabel.TextColor3 = theme.text
 	nameLabel.Font = Enum.Font.GothamBold
-	nameLabel.TextSize = 13
+	nameLabel.TextSize = 16
 	nameLabel.TextXAlignment = Enum.TextXAlignment.Center
 	nameLabel.TextTruncate = Enum.TextTruncate.AtEnd
-	nameLabel.Parent = content
+	nameLabel.Parent = textArea
 
 	-- Amount/Description
+	local descText = isGamepass and product.description or (formatNumber(product.amount) .. " Cash")
 	local descLabel = Instance.new("TextLabel")
-	descLabel.Size = UDim2.new(1, -8, 0, 14)
-	descLabel.Position = UDim2.fromOffset(4, 64)
+	descLabel.Size = UDim2.new(1, 0, 0, 32)
+	descLabel.Position = UDim2.fromOffset(0, 34)
 	descLabel.BackgroundTransparency = 1
-	descLabel.Text = isGamepass and product.description or (formatNumber(product.amount))
+	descLabel.Text = descText
 	descLabel.TextColor3 = theme.textSecondary
 	descLabel.Font = Enum.Font.Gotham
-	descLabel.TextSize = 10
+	descLabel.TextSize = 12
 	descLabel.TextXAlignment = Enum.TextXAlignment.Center
 	descLabel.TextWrapped = true
-	descLabel.Parent = content
+	descLabel.Parent = textArea
 
-	-- Bonus (if exists)
-	if not isGamepass and product.bonus and product.bonus > 0 then
-		local bonusLabel = Instance.new("TextLabel")
-		bonusLabel.Size = UDim2.new(1, -8, 0, 12)
-		bonusLabel.Position = UDim2.fromOffset(4, 80)
-		bonusLabel.BackgroundTransparency = 1
-		bonusLabel.Text = formatBonusText(product.bonus)
-		bonusLabel.TextColor3 = theme.accent
-		bonusLabel.Font = Enum.Font.GothamBold
-		bonusLabel.TextSize = 9
-		bonusLabel.TextXAlignment = Enum.TextXAlignment.Center
-		bonusLabel.Parent = content
-	end
-
-	-- Buy button
-	local owned = isGamepass and checkOwnership(product.id)
+	-- Price/Buy button at bottom
 	local buyBtn = Instance.new("TextButton")
-	buyBtn.Size = UDim2.new(1, -12, 0, 24)
-	buyBtn.Position = UDim2.new(0.5, 0, 1, -28)
-	buyBtn.AnchorPoint = Vector2.new(0.5, 0)
-	buyBtn.BackgroundColor3 = owned and theme.success or theme.accent
-	buyBtn.Text = owned and "✓ OWNED" or ("R$" .. tostring(product.price or 0))
+	buyBtn.Size = UDim2.new(1, -16, 0, 28)
+	buyBtn.Position = UDim2.new(0, 8, 1, -36)
+	buyBtn.BackgroundColor3 = owned and theme.success or cardColor
+	buyBtn.Text = owned and "✓ OWNED" or ("💰 R$" .. tostring(product.price or 0))
 	buyBtn.TextColor3 = Color3.new(1, 1, 1)
 	buyBtn.Font = Enum.Font.GothamBold
-	buyBtn.TextSize = 12
+	buyBtn.TextSize = 14
 	buyBtn.AutoButtonColor = false
 	buyBtn.Active = not owned
-	buyBtn.Parent = content
-	local btnCorner = Instance.new("UICorner"); btnCorner.CornerRadius = UDim.new(0, 8); btnCorner.Parent = buyBtn
+	buyBtn.Parent = card
+	local btnCorner = Instance.new("UICorner"); btnCorner.CornerRadius = UDim.new(0, 10); btnCorner.Parent = buyBtn
 
-	-- Button press effect
-	buyBtn.MouseButton1Down:Connect(function()
-		if not owned then
-			TweenService:Create(buyBtn,TweenInfo.new(0.08),{BackgroundColor3 = blend(buyBtn.BackgroundColor3, Color3.new(0,0,0), 0.15)}):Play()
-		end
-	end)
-	buyBtn.MouseButton1Up:Connect(function()
-		if not owned then
-			TweenService:Create(buyBtn,TweenInfo.new(0.12),{BackgroundColor3 = theme.accent}):Play()
-		end
-	end)
-
-	buyBtn.MouseButton1Click:Connect(function()
-		if owned then return end
-		buyBtn.Text = "..."
-		buyBtn.Active = false
-		self:promptPurchase(product, productType, buyBtn)
-	end)
-
-	-- Toggle for Auto Collect (compact version in corner)
+	-- Toggle for Auto Collect
 	if isGamepass and product.hasToggle and owned then
-		self:addToggleSwitch(product, content)
+		buyBtn.Text = "AUTO: OFF"
+		local state = false
+		if Remotes then
+			local rf = Remotes:FindFirstChild("GetAutoCollectState")
+			if rf and rf:IsA("RemoteFunction") then
+				local ok, val = pcall(function() return rf:InvokeServer() end)
+				if ok and type(val) == "boolean" then state = val end
+			end
+		end
+		
+		local function paint(on)
+			state = on
+			if on then
+				buyBtn.BackgroundColor3 = theme.success
+				buyBtn.Text = "AUTO: ON ✓"
+			else
+				buyBtn.BackgroundColor3 = theme.stroke
+				buyBtn.Text = "AUTO: OFF"
+			end
+		end
+		paint(state)
+		
+		buyBtn.Active = true
+		buyBtn.MouseButton1Click:Connect(function()
+			local nextState = not state
+			paint(nextState)
+			playSound("click")
+			if Remotes then
+				local ev = Remotes:FindFirstChild("AutoCollectToggle")
+				if ev and ev:IsA("RemoteEvent") then ev:FireServer(nextState) end
+			end
+		end)
+	else
+		-- Regular purchase button
+		buyBtn.MouseButton1Click:Connect(function()
+			if owned then return end
+			buyBtn.Text = "..."
+			buyBtn.Active = false
+			self:promptPurchase(product, productType, buyBtn)
+		end)
 	end
 
 	product.cardInstance = card
 	product.purchaseButton = buyBtn
 end
 
-function Shop:addToggleSwitch(product, parent)
-	-- Compact toggle that replaces the buy button when owned
-	local toggle = Instance.new("Frame")
-	toggle.Name = "ToggleSwitch"
-	toggle.Size = UDim2.new(1, -12, 0, 24)
-	toggle.Position = UDim2.new(0.5, 0, 1, -28)
-	toggle.AnchorPoint = Vector2.new(0.5, 0)
-	toggle.BackgroundColor3 = theme.stroke
-	toggle.BorderSizePixel = 0
-	toggle.Parent = parent
-	local tc = Instance.new("UICorner"); tc.CornerRadius = UDim.new(0, 8); tc.Parent = toggle
-
-	-- Hide the buy button since toggle replaces it
-	local buyBtn = parent:FindFirstChild("TextButton")
-	if buyBtn then buyBtn.Visible = false end
-
-	local label = Instance.new("TextLabel")
-	label.Size = UDim2.fromScale(1, 1)
-	label.BackgroundTransparency = 1
-	label.Text = "AUTO: OFF"
-	label.TextColor3 = theme.text
-	label.Font = Enum.Font.GothamBold
-	label.TextSize = 11
-	label.Parent = toggle
-
-	local btn = Instance.new("TextButton")
-	btn.Size = UDim2.fromScale(1, 1)
-	btn.BackgroundTransparency = 1
-	btn.Text = ""
-	btn.Parent = toggle
-
-	local state = false
-	if Remotes then
-		local rf = Remotes:FindFirstChild("GetAutoCollectState")
-		if rf and rf:IsA("RemoteFunction") then
-			local ok, val = pcall(function() return rf:InvokeServer() end)
-			if ok and type(val) == "boolean" then state = val end
-		end
-	end
-
-	local function paint(on)
-		state = on
-		if on then
-			toggle.BackgroundColor3 = theme.success
-			label.TextColor3 = Color3.new(1, 1, 1)
-			label.Text = "AUTO: ON ✓"
-		else
-			toggle.BackgroundColor3 = theme.stroke
-			label.TextColor3 = theme.text
-			label.Text = "AUTO: OFF"
-		end
-	end
-
-	paint(state)
-
-	-- Hover effect
-	btn.MouseEnter:Connect(function()
-		TweenService:Create(toggle,TweenInfo.new(0.12),{BackgroundColor3 = blend(toggle.BackgroundColor3, state and Color3.new(1,1,1) or Color3.new(0,0,0), 0.1)}):Play()
-	end)
-	btn.MouseLeave:Connect(function()
-		paint(state)
-	end)
-
-	btn.MouseButton1Click:Connect(function()
-		local nextState = not state
-		paint(nextState)
-		playSound("click")
-		if Remotes then
-			local ev = Remotes:FindFirstChild("AutoCollectToggle")
-			if ev and ev:IsA("RemoteEvent") then ev:FireServer(nextState) end
-		end
-	end)
-end
+-- Toggle functionality is now integrated into createProductCard
 
 -- ✅ DYNAMIC SIZING (from first script)
 function Shop:setupDynamicSizing()


### PR DESCRIPTION
Fixes the stretched and oversized pill buttons and tabs container in the Sanrio Shop GUI.

The previous sizing logic incorrectly used a large percentage of frame height for button dimensions and applied frame height to the tabs container's width, leading to distorted and excessively large UI elements. This PR adjusts the button and container sizing to use appropriate percentages and scaling for correct display.

---
<a href="https://cursor.com/background-agent?bcId=bc-680e4969-2260-42e8-8427-1d51ed441d00"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-680e4969-2260-42e8-8427-1d51ed441d00"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

